### PR TITLE
feat: deployment prep — dotenv loader, web migration runner, geocoding endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- `config/db.php` — dotenv loader for bare-PHP deployments (Plesk); reads `.env` from repo
+  root when env vars are not injected by Docker; no-op when vars already set (Docker compat)
+- `src/modules/admin/migrations.php` — web migration runner at `/admin/migrations`; creates
+  `schema_migrations` tracking table; lists pending/applied migrations; applies one at a time
+- `src/modules/admin/geocode_musicians.php` — admin HTTP endpoint at `/admin/geocode-musicians`;
+  replaces CLI-only `geocode_musicians.php` for Plesk deployments; shows current geocoding state
+
+---
+
+### Added
 - `db/migrations/010_travel_calculator_schema.sql` — schema additions for route-based travel
   cost calculation: `users` gains `home_address`, `home_lat/lng`, `transport_mode`;
   `venues` gains `lat/lng`, `requires_ferry`, `ferry_cost_estimate_cents`;

--- a/config/db.php
+++ b/config/db.php
@@ -1,4 +1,18 @@
 <?php
+// Load .env when running outside Docker (bare PHP on Plesk).
+// In Docker, env vars are already injected; putenv is a no-op for set vars.
+$_envFile = __DIR__ . '/../.env';
+if (file_exists($_envFile)) {
+    foreach (file($_envFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $_line) {
+        if (str_starts_with(trim($_line), '#') || !str_contains($_line, '=')) continue;
+        [$_k, $_v] = explode('=', $_line, 2);
+        $_k = trim($_k);
+        if (getenv($_k) === false) putenv($_k . '=' . trim($_v));
+    }
+    unset($_envFile, $_line, $_k, $_v);
+}
+unset($_envFile);
+
 $host = getenv('DB_HOST');
 $db   = getenv('MYSQL_DATABASE');
 $user = getenv('MYSQL_USER');

--- a/src/index.php
+++ b/src/index.php
@@ -36,6 +36,10 @@ $routes = [
 
     // Agent service
     ['#^/agent/process-inquiry$#',      'modules/agent/process_inquiry.php', 'owner'],
+
+    // Admin
+    ['#^/admin/migrations$#',           'modules/admin/migrations.php',         'admin'],
+    ['#^/admin/geocode-musicians$#',    'modules/admin/geocode_musicians.php',   'admin'],
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/index.php
+++ b/src/index.php
@@ -38,8 +38,8 @@ $routes = [
     ['#^/agent/process-inquiry$#',      'modules/agent/process_inquiry.php', 'owner'],
 
     // Admin
-    ['#^/admin/migrations$#',           'modules/admin/migrations.php',         'admin'],
-    ['#^/admin/geocode-musicians$#',    'modules/admin/geocode_musicians.php',   'admin'],
+    ['#^/admin/migrations$#',           'modules/admin/migrations.php',         'owner'],
+    ['#^/admin/geocode-musicians$#',    'modules/admin/geocode_musicians.php',   'owner'],
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/modules/admin/geocode_musicians.php
+++ b/src/modules/admin/geocode_musicians.php
@@ -8,10 +8,13 @@ $results = [];
 $ran     = false;
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    set_time_limit(0); // Geocoding is rate-limited to 1 req/s; disable PHP timeout.
     $ran  = true;
     $stmt = $pdo->query(
         "SELECT id, username, home_address FROM users
-         WHERE home_address IS NOT NULL AND home_lat IS NULL AND deleted_at IS NULL
+         WHERE home_address IS NOT NULL
+           AND (home_lat IS NULL OR home_lng IS NULL)
+           AND deleted_at IS NULL
          ORDER BY id ASC"
     );
     $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -41,7 +44,7 @@ $allUsers = $pdo->query(
      ORDER BY username ASC"
 )->fetchAll(PDO::FETCH_ASSOC);
 
-$pendingCount = count(array_filter($allUsers, fn($u) => $u['home_lat'] === null));
+$pendingCount = count(array_filter($allUsers, fn($u) => $u['home_lat'] === null || $u['home_lng'] === null));
 
 render_layout('Geocode musicians', function () use ($allUsers, $results, $ran, $pendingCount) {
 ?>
@@ -89,11 +92,11 @@ render_layout('Geocode musicians', function () use ($allUsers, $results, $ran, $
     <thead class="table-light"><tr><th>Username</th><th>Address</th><th>Lat</th><th>Lng</th></tr></thead>
     <tbody>
     <?php foreach ($allUsers as $u): ?>
-      <tr class="<?= $u['home_lat'] === null ? 'table-warning' : '' ?>">
+      <tr class="<?= ($u['home_lat'] === null || $u['home_lng'] === null) ? 'table-warning' : '' ?>">
         <td><?= htmlspecialchars($u['username']) ?></td>
         <td><?= htmlspecialchars($u['home_address'] ?? '—') ?></td>
-        <td class="font-monospace small"><?= $u['home_lat'] ?? '<span class="text-muted">—</span>' ?></td>
-        <td class="font-monospace small"><?= $u['home_lng'] ?? '<span class="text-muted">—</span>' ?></td>
+        <td class="font-monospace small"><?= $u['home_lat'] === null ? '<span class="text-muted">—</span>' : htmlspecialchars((string) $u['home_lat']) ?></td>
+        <td class="font-monospace small"><?= $u['home_lng'] === null ? '<span class="text-muted">—</span>' : htmlspecialchars((string) $u['home_lng']) ?></td>
       </tr>
     <?php endforeach; ?>
     </tbody>

--- a/src/modules/admin/geocode_musicians.php
+++ b/src/modules/admin/geocode_musicians.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../templates/layout.php';
+require_once __DIR__ . '/../../../../cli/lib/RoutingHelper.php';
+
+$results = [];
+$ran     = false;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $ran  = true;
+    $stmt = $pdo->query(
+        "SELECT id, username, home_address FROM users
+         WHERE home_address IS NOT NULL AND home_lat IS NULL AND deleted_at IS NULL
+         ORDER BY id ASC"
+    );
+    $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    if ($users) {
+        $update = $pdo->prepare('UPDATE users SET home_lat = ?, home_lng = ? WHERE id = ?');
+        foreach ($users as $u) {
+            $coords = RoutingHelper::geocode($u['home_address'] . ' Finland');
+            if ($coords === null) {
+                $results[] = ['username' => $u['username'], 'address' => $u['home_address'],
+                              'ok' => false, 'detail' => 'Nominatim returned no result'];
+            } else {
+                $update->execute([$coords['lat'], $coords['lng'], $u['id']]);
+                $results[] = ['username' => $u['username'], 'address' => $u['home_address'],
+                              'ok' => true,
+                              'detail' => "lat={$coords['lat']}, lng={$coords['lng']}"];
+            }
+            sleep(1); // Nominatim ToS: 1 req/s
+        }
+    }
+}
+
+// Summary of current state for display.
+$allUsers = $pdo->query(
+    "SELECT username, home_address, home_lat, home_lng FROM users
+     WHERE deleted_at IS NULL AND home_address IS NOT NULL
+     ORDER BY username ASC"
+)->fetchAll(PDO::FETCH_ASSOC);
+
+$pendingCount = count(array_filter($allUsers, fn($u) => $u['home_lat'] === null));
+
+render_layout('Geocode musicians', function () use ($allUsers, $results, $ran, $pendingCount) {
+?>
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2 class="mb-0">Geocode musician addresses</h2>
+  </div>
+  <p class="text-muted">
+    Resolves <code>home_address → home_lat/home_lng</code> via Nominatim for musicians
+    missing coordinates. Required for TravelCalculator to produce accurate km estimates.
+    Rate-limited to 1 request/second.
+  </p>
+
+  <?php if ($ran && empty($results)): ?>
+  <div class="alert alert-info">No musicians with missing coordinates — nothing to do.</div>
+  <?php elseif ($ran): ?>
+  <div class="alert <?= array_filter($results, fn($r) => !$r['ok']) ? 'alert-warning' : 'alert-success' ?>">
+    <?= count(array_filter($results, fn($r) => $r['ok'])) ?> geocoded,
+    <?= count(array_filter($results, fn($r) => !$r['ok'])) ?> failed.
+  </div>
+  <table class="table table-sm table-bordered mb-4">
+    <thead class="table-light"><tr><th>Username</th><th>Address</th><th>Result</th></tr></thead>
+    <tbody>
+    <?php foreach ($results as $r): ?>
+      <tr class="<?= $r['ok'] ? 'table-success' : 'table-danger' ?>">
+        <td><?= htmlspecialchars($r['username']) ?></td>
+        <td><?= htmlspecialchars($r['address']) ?></td>
+        <td class="font-monospace small"><?= htmlspecialchars($r['detail']) ?></td>
+      </tr>
+    <?php endforeach; ?>
+    </tbody>
+  </table>
+  <?php endif; ?>
+
+  <?php if ($pendingCount > 0): ?>
+  <form method="post" action="/admin/geocode-musicians"
+        onsubmit="return confirm('Run geocoding for <?= $pendingCount ?> musician(s)? This will take ~<?= $pendingCount ?> seconds.')">
+    <button class="btn btn-primary">Run geocoding (<?= $pendingCount ?> pending)</button>
+  </form>
+  <?php else: ?>
+  <div class="alert alert-success">All musicians with home addresses have coordinates.</div>
+  <?php endif; ?>
+
+  <h5 class="mt-4">Current state</h5>
+  <table class="table table-sm table-bordered">
+    <thead class="table-light"><tr><th>Username</th><th>Address</th><th>Lat</th><th>Lng</th></tr></thead>
+    <tbody>
+    <?php foreach ($allUsers as $u): ?>
+      <tr class="<?= $u['home_lat'] === null ? 'table-warning' : '' ?>">
+        <td><?= htmlspecialchars($u['username']) ?></td>
+        <td><?= htmlspecialchars($u['home_address'] ?? '—') ?></td>
+        <td class="font-monospace small"><?= $u['home_lat'] ?? '<span class="text-muted">—</span>' ?></td>
+        <td class="font-monospace small"><?= $u['home_lng'] ?? '<span class="text-muted">—</span>' ?></td>
+      </tr>
+    <?php endforeach; ?>
+    </tbody>
+  </table>
+<?php
+});

--- a/src/modules/admin/geocode_musicians.php
+++ b/src/modules/admin/geocode_musicians.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../../templates/layout.php';
-require_once __DIR__ . '/../../../../cli/lib/RoutingHelper.php';
+require_once __DIR__ . '/../../../cli/lib/RoutingHelper.php';
 
 $results = [];
 $ran     = false;

--- a/src/modules/admin/migrations.php
+++ b/src/modules/admin/migrations.php
@@ -22,7 +22,8 @@ if ($migrationsDir === null) {
     });
     exit;
 }
-$files = glob($migrationsDir . '/*.sql');
+
+$files = glob($migrationsDir . '/*.sql') ?: [];
 natsort($files);
 
 $applied = $pdo->query("SELECT version FROM schema_migrations ORDER BY version")
@@ -46,6 +47,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $error = 'Could not read migration file.';
         } else {
             try {
+                $pdo->beginTransaction();
                 // Split on semicolons to execute multi-statement files.
                 $statements = array_filter(
                     array_map('trim', explode(';', $sql)),
@@ -56,10 +58,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
                 $pdo->prepare("INSERT INTO schema_migrations (version) VALUES (?)")
                     ->execute([$target]);
+                $pdo->commit();
                 $appliedSet[$target] = true;
                 $notice = "Applied: $target";
             } catch (Throwable $e) {
-                $error = 'Migration failed: ' . $e->getMessage();
+                if ($pdo->inTransaction()) $pdo->rollBack();
+                $error = 'Migration failed: ' . htmlspecialchars($e->getMessage());
             }
         }
     }
@@ -75,9 +79,12 @@ render_layout('Migrations', function () use ($files, $appliedSet, $notice, $erro
   <div class="alert alert-success"><?= htmlspecialchars($notice) ?></div>
   <?php endif; ?>
   <?php if ($error): ?>
-  <div class="alert alert-danger"><?= htmlspecialchars($error) ?></div>
+  <div class="alert alert-danger"><?= $error ?></div>
   <?php endif; ?>
 
+  <?php if (empty($files)): ?>
+  <div class="alert alert-info">No migration files found.</div>
+  <?php else: ?>
   <table class="table table-sm table-bordered">
     <thead class="table-light">
       <tr>
@@ -97,8 +104,8 @@ render_layout('Migrations', function () use ($files, $appliedSet, $notice, $erro
         <td>
           <?php if (!$isApplied): ?>
           <form method="post" action="/admin/migrations"
-                onsubmit="return confirm('Apply <?= htmlspecialchars($version, ENT_QUOTES) ?>?')">
-            <input type="hidden" name="version" value="<?= htmlspecialchars($version) ?>">
+                onsubmit="return confirm('Apply <?= htmlspecialchars($version, ENT_QUOTES, 'UTF-8') ?>?')">
+            <input type="hidden" name="version" value="<?= htmlspecialchars($version, ENT_QUOTES, 'UTF-8') ?>">
             <button class="btn btn-sm btn-warning">Apply</button>
           </form>
           <?php else: ?>
@@ -109,5 +116,6 @@ render_layout('Migrations', function () use ($files, $appliedSet, $notice, $erro
     <?php endforeach; ?>
     </tbody>
   </table>
+  <?php endif; ?>
 <?php
 });

--- a/src/modules/admin/migrations.php
+++ b/src/modules/admin/migrations.php
@@ -1,0 +1,103 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../templates/layout.php';
+
+// Ensure schema_migrations tracking table exists.
+$pdo->exec("
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+        version     VARCHAR(100) NOT NULL PRIMARY KEY,
+        applied_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+");
+
+$migrationsDir = __DIR__ . '/../../../../db/migrations';
+$files = glob($migrationsDir . '/*.sql');
+natsort($files);
+
+$applied = $pdo->query("SELECT version FROM schema_migrations ORDER BY version")
+               ->fetchAll(PDO::FETCH_COLUMN);
+$appliedSet = array_flip($applied);
+
+$notice = null;
+$error  = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $target = $_POST['version'] ?? '';
+    // Validate: must be a known migration filename, not already applied.
+    $validVersions = array_map('basename', $files);
+    if (!in_array($target, $validVersions, true)) {
+        $error = 'Unknown migration version.';
+    } elseif (isset($appliedSet[$target])) {
+        $error = 'Migration already applied.';
+    } else {
+        $sql = file_get_contents($migrationsDir . '/' . $target);
+        if ($sql === false) {
+            $error = 'Could not read migration file.';
+        } else {
+            try {
+                // Split on semicolons to execute multi-statement files.
+                $statements = array_filter(
+                    array_map('trim', explode(';', $sql)),
+                    fn($s) => $s !== ''
+                );
+                foreach ($statements as $stmt) {
+                    $pdo->exec($stmt);
+                }
+                $pdo->prepare("INSERT INTO schema_migrations (version) VALUES (?)")
+                    ->execute([$target]);
+                $appliedSet[$target] = true;
+                $notice = "Applied: $target";
+            } catch (Throwable $e) {
+                $error = 'Migration failed: ' . $e->getMessage();
+            }
+        }
+    }
+}
+
+render_layout('Migrations', function () use ($files, $appliedSet, $notice, $error) {
+?>
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2 class="mb-0">Schema migrations</h2>
+  </div>
+
+  <?php if ($notice): ?>
+  <div class="alert alert-success"><?= htmlspecialchars($notice) ?></div>
+  <?php endif; ?>
+  <?php if ($error): ?>
+  <div class="alert alert-danger"><?= htmlspecialchars($error) ?></div>
+  <?php endif; ?>
+
+  <table class="table table-sm table-bordered">
+    <thead class="table-light">
+      <tr>
+        <th>Migration</th>
+        <th style="width:130px">Status</th>
+        <th style="width:130px">Action</th>
+      </tr>
+    </thead>
+    <tbody>
+    <?php foreach ($files as $file):
+        $version = basename($file);
+        $isApplied = isset($appliedSet[$version]);
+    ?>
+      <tr class="<?= $isApplied ? 'table-success' : '' ?>">
+        <td class="font-monospace"><?= htmlspecialchars($version) ?></td>
+        <td><?= $isApplied ? '<span class="text-success">Applied</span>' : '<span class="text-warning">Pending</span>' ?></td>
+        <td>
+          <?php if (!$isApplied): ?>
+          <form method="post" action="/admin/migrations"
+                onsubmit="return confirm('Apply <?= htmlspecialchars($version, ENT_QUOTES) ?>?')">
+            <input type="hidden" name="version" value="<?= htmlspecialchars($version) ?>">
+            <button class="btn btn-sm btn-warning">Apply</button>
+          </form>
+          <?php else: ?>
+          <span class="text-muted">—</span>
+          <?php endif; ?>
+        </td>
+      </tr>
+    <?php endforeach; ?>
+    </tbody>
+  </table>
+<?php
+});

--- a/src/modules/admin/migrations.php
+++ b/src/modules/admin/migrations.php
@@ -11,7 +11,17 @@ $pdo->exec("
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
 ");
 
-$migrationsDir = __DIR__ . '/../../../../db/migrations';
+// On Plesk: document root is httpdocs/src/, so repo root is one level above src/.
+// __DIR__ = .../httpdocs/src/modules/admin → ../../../ = httpdocs/ (repo root)
+// In Docker: db/ is not mounted into the PHP container; use `make migrate-dev` instead.
+$migrationsDir = realpath(__DIR__ . '/../../../db/migrations') ?: null;
+if ($migrationsDir === null) {
+    render_layout('Migrations', function () {
+        echo '<div class="alert alert-warning">Migration files are not accessible from this environment. '
+           . 'Use <code>make migrate-dev</code> in development.</div>';
+    });
+    exit;
+}
 $files = glob($migrationsDir . '/*.sql');
 natsort($files);
 

--- a/src/modules/agent/process_inquiry.php
+++ b/src/modules/agent/process_inquiry.php
@@ -22,7 +22,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $fields = InquiryExtractor::extract($rawText);
     } catch (RuntimeException $e) {
         error_log('InquiryExtractor failed: ' . $e->getMessage());
-        $extractionError = 'AI extraction failed: ' . $e->getMessage()
+        $extractionError = 'AI extraction failed: ' . htmlspecialchars($e->getMessage())
             . ' — try again, or use the <a href="/gigs/new">manual form</a>.';
         goto render_form;
     }


### PR DESCRIPTION
## Summary

- `config/db.php`: parses `.env` file on bare-PHP hosts (Plesk); transparent no-op under Docker where env vars are already injected
- `src/modules/admin/migrations.php`: web UI at `/admin/migrations` to apply schema migrations one at a time; creates and maintains a `schema_migrations` tracking table; replaces `make migrate` for production deployments without SSH
- `src/modules/admin/geocode_musicians.php`: HTTP endpoint at `/admin/geocode-musicians` to geocode musician home addresses via Nominatim; replaces the CLI-only `geocode_musicians.php` for Plesk deployments; shows current geocoding state per musician
- Both admin routes require `owner` role minimum
- Minor: escape `$e->getMessage()` in `process_inquiry.php` error output

## Test plan

- [ ] `/admin/migrations` loads and lists all 10 migrations as pending on a fresh DB
- [ ] Applying a migration marks it as Applied and records it in `schema_migrations`
- [ ] Applying the same migration twice shows "already applied" error
- [ ] `/admin/geocode-musicians` shows current lat/lng state per musician
- [ ] Geocoding run updates `home_lat`/`home_lng` for musicians missing coordinates
- [ ] Both routes redirect to login when accessed unauthenticated
- [ ] `config/db.php` connects successfully in both Docker (dev) and bare-PHP (Plesk) environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
