### PR TITLE
feat: Tilauslomake → confirmed status + payload in order_description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Tilauslomake gigs created with `status=confirmed`** — booking confirmation form semantically
+  maps to confirmed, not inquiry; `GigCreator::create()` now accepts an optional `$status` param
+  (default `'inquiry'`); Tilauslomake handler passes `'confirmed'`
+- **Webflow payload preserved in `order_description`** — Tilauslomake builds a concise summary
+  string (`Tilauslomake – {date} – {customer}`); Email Form falls back raw message text if AI
+  extraction leaves `order_description` empty
+
+### Changed
+- `GigCreator::create()` — added optional `$status` parameter (default `'inquiry'`); validates
+  against the full `gigs.status` ENUM; replaces hard-coded `'inquiry'` literal in INSERT
+
+---
+
+### Added (previous)
 - **User management UI** — `/admin/users` list, `/admin/users/new` and `/admin/users/{id}/edit`
   create/edit forms, `/admin/users/{id}/delete` soft-delete handler; owners can create musician
   and owner accounts; admin+ can also create admin accounts; developer accounts not creatable via UI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,16 @@ Stack: PHP 8.2 + Apache · MariaDB 10.11 · Vue 3 + Bootstrap 5 · Docker
 
 ---
 
+## Branch strategy
+
+- `main` — production; only receives PRs from `dev`
+- `dev` — integration branch; receives PRs from feature branches
+- `feat/<topic>` — all new work; branched from `dev`, merged back to `dev` via PR
+- Hotfixes: `fix/<topic>` branched from `dev` (or `main` if truly urgent)
+- **Never commit new features directly to `dev` or `main`**
+
+---
+
 ## Workflow rules
 
 - **Always ask** before introducing a new architectural pattern or dependency

--- a/src/modules/agent/lib/GigCreator.php
+++ b/src/modules/agent/lib/GigCreator.php
@@ -37,10 +37,12 @@ class GigCreator
      * @param  PDO    $pdo
      * @param  array  $fields  See class docblock for expected keys.
      * @param  string $channel ENUM value from gigs.channel (e.g. 'mail', 'saturday_band')
+     * @param  string $status  ENUM value from gigs.status (default 'inquiry')
      * @return int             ID of the newly created gig row.
      * @throws RuntimeException on database failure.
+     * @throws \InvalidArgumentException if $status is not a valid enum value.
      */
-    public static function create(PDO $pdo, array $fields, string $channel): int
+    public static function create(PDO $pdo, array $fields, string $channel, string $status = 'inquiry'): int
     {
         $customerName    = $fields['customer_name']      ?? 'Unknown';
         $customerType    = $fields['customer_type']      ?? 'other';
@@ -64,6 +66,9 @@ class GigCreator
 
         if (!in_array($customerType, ['wedding', 'company', 'other'], true)) {
             $customerType = 'other';
+        }
+        if (!in_array($status, ['inquiry', 'quoted', 'confirmed', 'delivered', 'cancelled', 'declined'], true)) {
+            throw new \InvalidArgumentException("Invalid gig status: $status");
         }
         if ($customerName === '') $customerName = 'Unknown';
         if ($venueName    === '') $venueName    = 'Unknown';
@@ -134,10 +139,10 @@ class GigCreator
                     qty_ennakkoroudaus, qty_song_requests_extra, qty_extra_performances,
                     qty_background_music_h, qty_live_album, discount_cents,
                     notes)
-                 VALUES (?, ?, ?, ?, 'inquiry', ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, 0, 0, 0, 0, ?)"
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, 0, 0, 0, 0, ?)"
             )->execute([
                 $customerId, $contactId, $venueId, $gigDate,
-                $channel, $customerType, $orderDesc,
+                $status, $channel, $customerType, $orderDesc,
                 $basePriceCents, $basePriceCents,
                 $car1Km, $car2Km ?? 0, $otherTravelCents,
                 $notes,

--- a/src/modules/webhook/webflow.php
+++ b/src/modules/webhook/webflow.php
@@ -163,6 +163,11 @@ function handleEmailForm(PDO $pdo, array $data): int
         $fields['contact_email'] = $email;
     }
 
+    // Fall back to raw message if AI extraction left order_description empty.
+    if (empty($fields['order_description']) && $message !== '') {
+        $fields['order_description'] = mb_substr($message, 0, 255);
+    }
+
     return runPipelineAndCreate($pdo, $fields, 'saturday_band');
 }
 
@@ -199,6 +204,18 @@ function handleTilauslomake(PDO $pdo, array $data): int
     }
     $notes = $notesParts ? implode("\n", $notesParts) : null;
 
+    // Build a concise order_description from structured fields.
+    $descParts = ['Tilauslomake'];
+    if ($gigDate !== null) {
+        $descParts[] = $gigDate;
+    } elseif ($dateRaw !== '') {
+        $descParts[] = $dateRaw;
+    }
+    if ($customerName !== '') {
+        $descParts[] = $customerName;
+    }
+    $orderDesc = mb_substr(implode(' – ', $descParts), 0, 255);
+
     $fields = [
         'customer_name'      => $customerName,
         'customer_type'      => $customerType,
@@ -210,17 +227,17 @@ function handleTilauslomake(PDO $pdo, array $data): int
         'contact_last_name'  => $lastName,
         'contact_email'      => $email ?: null,
         'contact_phone'      => $phone ?: null,
-        'order_description'  => null,
+        'order_description'  => $orderDesc,
         'notes'              => $notes,
     ];
 
-    return runPipelineAndCreate($pdo, $fields, 'saturday_band');
+    return runPipelineAndCreate($pdo, $fields, 'saturday_band', 'confirmed');
 }
 
 /**
  * Shared geocoding + travel + price calculation + GigCreator::create().
  */
-function runPipelineAndCreate(PDO $pdo, array $fields, string $channel): int
+function runPipelineAndCreate(PDO $pdo, array $fields, string $channel, string $status = 'inquiry'): int
 {
     $venueName    = trim($fields['venue_name']    ?? '');
     $venueAddress = trim($fields['venue_address'] ?? '') ?: null;
@@ -310,5 +327,5 @@ function runPipelineAndCreate(PDO $pdo, array $fields, string $channel): int
         'car2_km'            => $car2Km,
         'other_travel_cents' => $otherTravelCents,
         'base_price_cents'   => $basePriceCents,
-    ]), $channel);
+    ]), $channel, $status);
 }


### PR DESCRIPTION
## Summary

- `GigCreator::create()` accepts an optional `$status` parameter (default `'inquiry'`), validated against the full `gigs.status` ENUM
- `handleTilauslomake()` passes `status='confirmed'` — the booking confirmation form is semantically a confirmed booking, not an inquiry
- `handleTilauslomake()` builds a concise `order_description`: `Tilauslomake – {date} – {customer}`
- `handleEmailForm()` falls back to raw `$message` → `order_description` if AI extraction leaves it empty

## Test plan

- [ ] Submit a Tilauslomake on saturday.band → gig appears in ERP with `status=confirmed` and `order_description` populated
- [ ] Submit an Email Form → `order_description` populated (AI output or raw message fallback)
- [ ] `process_inquiry.php` CLI workflow unchanged — gigs created with `status=inquiry` (no fourth arg → default)
- [ ] Trigger with an invalid status value → `InvalidArgumentException` thrown

🤖 Generated with [Claude Code](https://claude.com/claude-code)