### PR TITLE
feat: route calculation transparency (migration 011)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Route calculation transparency** — TravelCalculator now returns labelled waypoints and
+  per-leg km for each car route; stored as `car1_route_json` / `car2_route_json` (TEXT) on the
+  `gigs` row; gig detail view shows a collapsible "Route detail" table with waypoints and leg
+  distances; "Recalculate travel" also writes route JSON on recalculation
+- `db/migrations/011_route_json.sql` — adds `car1_route_json` and `car2_route_json` columns
+
+### Changed
+- `RoutingHelper::waypointRouteKm()` — delegates to new `waypointRouteDetail()` (no behaviour change)
+- `RoutingHelper::waypointRouteDetail()` — new method; returns `{total_km, legs_km[]}` from OSRM
+- `TravelCalculator::calculateFromPersonnel()` — now returns `car1_route` and `car2_route` arrays
+  alongside existing keys; all waypoints carry labels for display
+- `GigCreator::create()` — includes `car1_route_json` / `car2_route_json` in INSERT
+- `src/modules/gigs/travel_calculate.php` — UPDATE writes route JSON on recalculation
+
+---
+
+### Added (previous)
 - **User management UI** — `/admin/users` list, `/admin/users/new` and `/admin/users/{id}/edit`
   create/edit forms, `/admin/users/{id}/delete` soft-delete handler; owners can create musician
   and owner accounts; admin+ can also create admin accounts; developer accounts not creatable via UI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,16 @@ Stack: PHP 8.2 + Apache · MariaDB 10.11 · Vue 3 + Bootstrap 5 · Docker
 
 ---
 
+## Branch strategy
+
+- `main` — production; only receives PRs from `dev`
+- `dev` — integration branch; receives PRs from feature branches
+- `feat/<topic>` — all new work; branched from `dev`, merged back to `dev` via PR
+- Hotfixes: `fix/<topic>` branched from `dev` (or `main` if truly urgent)
+- **Never commit new features directly to `dev` or `main`**
+
+---
+
 ## Workflow rules
 
 - **Always ask** before introducing a new architectural pattern or dependency

--- a/cli/lib/RoutingHelper.php
+++ b/cli/lib/RoutingHelper.php
@@ -61,6 +61,18 @@ class RoutingHelper
      */
     public static function waypointRouteKm(array $waypoints): ?float
     {
+        $detail = self::waypointRouteDetail($waypoints);
+        return $detail !== null ? $detail['total_km'] : null;
+    }
+
+    /**
+     * Compute total and per-leg driving distances for an ordered sequence of waypoints via OSRM.
+     *
+     * @param  array<array{float, float}> $waypoints  Each element: [lat, lng]. Min 2.
+     * @return array{total_km: float, legs_km: float[]}|null  null on failure.
+     */
+    public static function waypointRouteDetail(array $waypoints): ?array
+    {
         if (count($waypoints) < 2) {
             return null;
         }
@@ -88,6 +100,13 @@ class RoutingHelper
         if (($data['code'] ?? '') !== 'Ok' || empty($data['routes'][0]['distance'])) {
             return null;
         }
-        return round($data['routes'][0]['distance'] / 1000, 1);
+
+        $totalKm = round($data['routes'][0]['distance'] / 1000, 1);
+        $legsKm  = array_map(
+            fn($leg) => round(($leg['distance'] ?? 0) / 1000, 1),
+            $data['routes'][0]['legs'] ?? []
+        );
+
+        return ['total_km' => $totalKm, 'legs_km' => $legsKm];
     }
 }

--- a/cli/lib/TravelCalculator.php
+++ b/cli/lib/TravelCalculator.php
@@ -84,10 +84,11 @@ class TravelCalculator
         array $ferry = ['requires_ferry' => false, 'cost_eur' => 0.0]
     ): array {
         $warnings   = [];
-        $car1Driver = null;   // [lat, lng]
-        $car1Stops  = [];     // ordered waypoints added between driver home and venue
-        $car2Driver = null;   // [lat, lng]
-        $car2Stops  = [];     // ordered waypoints added between driver home and venue
+        // Each entry: ['lat' => float, 'lng' => float, 'label' => string]
+        $car1Driver = null;
+        $car1Stops  = [];
+        $car2Driver = null;
+        $car2Stops  = [];
 
         foreach ($personnel as $p) {
             $effectiveMode     = $p['transport_override'] ?? $p['transport_mode'];
@@ -101,7 +102,7 @@ class TravelCalculator
                     if (!$hasCoords) {
                         $warnings[] = "Car 1 driver ({$p['username']}) has no home coordinates — Car 1 route unavailable.";
                     } else {
-                        $car1Driver = [$lat, $lng];
+                        $car1Driver = ['lat' => $lat, 'lng' => $lng, 'label' => "{$p['username']} (keyboards, Car 1 driver)"];
                     }
                     break;
 
@@ -109,7 +110,7 @@ class TravelCalculator
                 case 'vocals':
                     // Always Car 1 passenger (Joni, Alina — Turku-based)
                     if ($hasCoords) {
-                        $car1Stops[] = [$lat, $lng];
+                        $car1Stops[] = ['lat' => $lat, 'lng' => $lng, 'label' => "{$p['username']} ({$p['role']})"];
                     } else {
                         $warnings[] = "{$p['username']} ({$p['role']}) has no home coordinates — pickup waypoint skipped.";
                     }
@@ -122,7 +123,7 @@ class TravelCalculator
                         break;
                     }
                     if ($hasCoords) {
-                        $car2Stops[] = [$lat, $lng];
+                        $car2Stops[] = ['lat' => $lat, 'lng' => $lng, 'label' => "{$p['username']} (guitar)"];
                     } else {
                         $warnings[] = "{$p['username']} (guitar) has no home coordinates — Car 2 pickup skipped.";
                     }
@@ -133,7 +134,7 @@ class TravelCalculator
                     if (!$hasCoords) {
                         $warnings[] = "Car 2 driver ({$p['username']}) has no home coordinates — Car 2 route unavailable.";
                     } else {
-                        $car2Driver = [$lat, $lng];
+                        $car2Driver = ['lat' => $lat, 'lng' => $lng, 'label' => "{$p['username']} (bass, Car 2 driver)"];
                     }
                     break;
 
@@ -144,14 +145,14 @@ class TravelCalculator
                     } elseif ($effectiveMode === 'passenger') {
                         // Car 1 passenger (Toni — Turku-based passenger)
                         if ($hasCoords) {
-                            $car1Stops[] = [$lat, $lng];
+                            $car1Stops[] = ['lat' => $lat, 'lng' => $lng, 'label' => "{$p['username']} (sound engineering)"];
                         } else {
                             $warnings[] = "{$p['username']} (sound engineering, Car 1) has no home coordinates — pickup waypoint skipped.";
                         }
                     } else {
                         // car_owner without override = Car 2 pickup (Valtteri typical case)
                         if ($hasCoords) {
-                            $car2Stops[] = [$lat, $lng];
+                            $car2Stops[] = ['lat' => $lat, 'lng' => $lng, 'label' => "{$p['username']} (sound engineering, Car 2 pickup)"];
                         } else {
                             $warnings[] = "{$p['username']} (sound engineering, Car 2 pickup) has no home coordinates — waypoint skipped.";
                         }
@@ -160,8 +161,10 @@ class TravelCalculator
             }
         }
 
-        $car1Km = self::computeCarRoute($car1Driver, $car1Stops, $venueLat, $venueLng, true);
-        $car2Km = self::computeCarRoute($car2Driver, $car2Stops, $venueLat, $venueLng, false);
+        $car1Result = self::computeCarRouteDetail($car1Driver, $car1Stops, $venueLat, $venueLng, true);
+        $car2Result = self::computeCarRouteDetail($car2Driver, $car2Stops, $venueLat, $venueLng, false);
+        $car1Km = $car1Result['km'];
+        $car2Km = $car2Result['km'];
 
         if ($car1Driver !== null && $car1Km === null) {
             $warnings[] = 'Car 1 OSRM routing failed — check network and waypoint coordinates.';
@@ -180,48 +183,67 @@ class TravelCalculator
             'car2_km'         => $car2Km,
             'ferry_costs_eur' => $ferryCosts,
             'warnings'        => $warnings,
+            'car1_route'      => $car1Result['route'],
+            'car2_route'      => $car2Result['route'],
         ];
     }
 
     /**
-     * Build and query one car's route.
+     * Build and query one car's route, returning km and labelled route detail.
      * Route: driver home → [trailer if Car 1] → stops[] → venue → back to driver home (× 2 approx).
      *
-     * @param array|null $driver  [lat, lng] or null
-     * @param array      $stops   additional pickup waypoints [[lat,lng], ...]
+     * @param array|null $driver  ['lat', 'lng', 'label'] or null
+     * @param array      $stops   additional pickup waypoints [['lat','lng','label'], ...]
      * @param float      $venueLat
      * @param float      $venueLng
      * @param bool       $isCar1  if true, inserts trailer waypoint after driver home
-     * @return float|null  round-trip km or null if no driver / OSRM failure
+     * @return array{km: float|null, route: array|null}
      */
-    private static function computeCarRoute(
+    private static function computeCarRouteDetail(
         ?array $driver,
         array  $stops,
         float  $venueLat,
         float  $venueLng,
         bool   $isCar1
-    ): ?float {
+    ): array {
         if ($driver === null) {
-            return null;
+            return ['km' => null, 'route' => null];
         }
 
-        $waypoints = [$driver];
+        // Labelled waypoints for display
+        $labelledWaypoints = [
+            ['label' => $driver['label'], 'lat' => $driver['lat'], 'lng' => $driver['lng']],
+        ];
 
         if ($isCar1) {
-            $waypoints[] = [self::TRAILER_LAT, self::TRAILER_LNG];
+            $labelledWaypoints[] = ['label' => 'Trailer (Opettajankatu 9)', 'lat' => self::TRAILER_LAT, 'lng' => self::TRAILER_LNG];
         }
 
         foreach ($stops as $stop) {
-            $waypoints[] = $stop;
+            $labelledWaypoints[] = ['label' => $stop['label'], 'lat' => $stop['lat'], 'lng' => $stop['lng']];
         }
 
-        $waypoints[] = [$venueLat, $venueLng];
+        $labelledWaypoints[] = ['label' => 'Venue', 'lat' => $venueLat, 'lng' => $venueLng];
 
-        $oneWayKm = RoutingHelper::waypointRouteKm($waypoints);
-        if ($oneWayKm === null) {
-            return null;
+        // Flat [lat, lng] pairs for OSRM
+        $coords = array_map(fn($w) => [$w['lat'], $w['lng']], $labelledWaypoints);
+
+        $detail = RoutingHelper::waypointRouteDetail($coords);
+        if ($detail === null) {
+            return ['km' => null, 'route' => null];
         }
-        return round($oneWayKm * 2, 1); // round trip
+
+        $oneWayKm    = $detail['total_km'];
+        $roundTripKm = round($oneWayKm * 2, 1);
+
+        return [
+            'km'    => $roundTripKm,
+            'route' => [
+                'waypoints'   => $labelledWaypoints,
+                'one_way_km'  => $oneWayKm,
+                'legs_km'     => $detail['legs_km'],
+            ],
+        ];
     }
 
     /**

--- a/db/migrations/011_route_json.sql
+++ b/db/migrations/011_route_json.sql
@@ -1,0 +1,9 @@
+-- Migration 011: add car route JSON columns to gigs
+-- Stores the calculated route detail (waypoints + per-leg km) so it is
+-- visible in the gig detail view and auditable after recalculation.
+
+ALTER TABLE gigs
+  ADD COLUMN car1_route_json TEXT DEFAULT NULL
+    COMMENT 'JSON: {"waypoints":[{"label":"...","lat":...,"lng":...}],"one_way_km":...,"legs_km":[...]}',
+  ADD COLUMN car2_route_json TEXT DEFAULT NULL
+    COMMENT 'JSON: same shape as car1_route_json';

--- a/db/schema/core.sql
+++ b/db/schema/core.sql
@@ -148,6 +148,9 @@ CREATE TABLE IF NOT EXISTS gigs (
     car1_distance_km        DECIMAL(7,1)             DEFAULT NULL,
     car2_distance_km        DECIMAL(7,1)             DEFAULT 0.0,
     other_travel_costs_cents INT                     DEFAULT 0,
+    -- Route detail JSON: {"waypoints":[{"label","lat","lng"}],"one_way_km","legs_km":[]}
+    car1_route_json         TEXT                     DEFAULT NULL,
+    car2_route_json         TEXT                     DEFAULT NULL,
     -- Granular pricing inputs (see PriceCalculator; persisted so the edit form pre-populates)
     pricing_tier1            TINYINT(1)              NOT NULL DEFAULT 0, -- on-season Saturday flag
     pricing_tier2            TINYINT(1)              NOT NULL DEFAULT 0, -- high-demand date flag

--- a/src/modules/agent/lib/GigCreator.php
+++ b/src/modules/agent/lib/GigCreator.php
@@ -61,6 +61,8 @@ class GigCreator
         $car2Km          = $fields['car2_km']            ?? null;
         $otherTravelCents = (int)($fields['other_travel_cents'] ?? 0);
         $basePriceCents  = (int)($fields['base_price_cents']    ?? 0);
+        $car1RouteJson   = isset($fields['car1_route']) ? json_encode($fields['car1_route']) : null;
+        $car2RouteJson   = isset($fields['car2_route']) ? json_encode($fields['car2_route']) : null;
 
         if (!in_array($customerType, ['wedding', 'company', 'other'], true)) {
             $customerType = 'other';
@@ -130,16 +132,18 @@ class GigCreator
                    (customer_id, contact_id, venue_id, gig_date, status, channel, customer_type,
                     order_description, base_price_cents, quoted_price_cents,
                     car1_distance_km, car2_distance_km, other_travel_costs_cents,
+                    car1_route_json, car2_route_json,
                     pricing_tier1, pricing_tier2,
                     qty_ennakkoroudaus, qty_song_requests_extra, qty_extra_performances,
                     qty_background_music_h, qty_live_album, discount_cents,
                     notes)
-                 VALUES (?, ?, ?, ?, 'inquiry', ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, 0, 0, 0, 0, ?)"
+                 VALUES (?, ?, ?, ?, 'inquiry', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, 0, 0, 0, 0, ?)"
             )->execute([
                 $customerId, $contactId, $venueId, $gigDate,
                 $channel, $customerType, $orderDesc,
                 $basePriceCents, $basePriceCents,
                 $car1Km, $car2Km ?? 0, $otherTravelCents,
+                $car1RouteJson, $car2RouteJson,
                 $notes,
             ]);
             $gigId = (int)$pdo->lastInsertId();

--- a/src/modules/agent/process_inquiry.php
+++ b/src/modules/agent/process_inquiry.php
@@ -120,6 +120,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $car1Km           = $travel['car1_km'];
         $car2Km           = $travel['car2_km'] ?? 0;
         $otherTravelCents = (int)round($travel['ferry_costs_eur'] * 100);
+        $car1Route        = $travel['car1_route'] ?? null;
+        $car2Route        = $travel['car2_route'] ?? null;
     }
 
     // --- Price calculation with extracted inputs (baseline) -------------------
@@ -169,6 +171,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             'car2_km'            => $car2Km,
             'other_travel_cents' => $otherTravelCents,
             'base_price_cents'   => $basePriceCents,
+            'car1_route'         => $car1Route ?? null,
+            'car2_route'         => $car2Route ?? null,
         ], 'mail');
     } catch (RuntimeException $e) {
         error_log('Agent inquiry save failed: ' . $e->getMessage());

--- a/src/modules/gigs/detail.php
+++ b/src/modules/gigs/detail.php
@@ -231,6 +231,37 @@ render_layout($gig['customer_name'], function () use ($gig, $transitions, $perso
             </dd>
           </dl>
 
+          <?php
+          $car1Route = isset($gig['car1_route_json']) ? json_decode($gig['car1_route_json'], true) : null;
+          $car2Route = isset($gig['car2_route_json']) ? json_decode($gig['car2_route_json'], true) : null;
+          if ($car1Route || $car2Route):
+          ?>
+          <div class="mt-2">
+            <a class="small text-muted" data-bs-toggle="collapse" href="#routeDetail" role="button">
+              Route detail ▾
+            </a>
+            <div class="collapse mt-2" id="routeDetail">
+              <?php foreach ([['Car 1', $car1Route], ['Car 2', $car2Route]] as [$label, $route]): ?>
+              <?php if ($route): ?>
+              <p class="small fw-semibold mb-1"><?= $label ?> — one-way <?= $route['one_way_km'] ?> km (round trip <?= round($route['one_way_km'] * 2, 1) ?> km)</p>
+              <table class="table table-sm table-bordered small mb-3">
+                <thead class="table-light"><tr><th>#</th><th>Waypoint</th><th class="text-end">Leg km</th></tr></thead>
+                <tbody>
+                <?php foreach ($route['waypoints'] as $i => $wp): ?>
+                <tr>
+                  <td><?= $i + 1 ?></td>
+                  <td><?= htmlspecialchars($wp['label']) ?></td>
+                  <td class="text-end"><?= isset($route['legs_km'][$i]) ? $route['legs_km'][$i] . ' km' : '—' ?></td>
+                </tr>
+                <?php endforeach; ?>
+                </tbody>
+              </table>
+              <?php endif; ?>
+              <?php endforeach; ?>
+            </div>
+          </div>
+          <?php endif; ?>
+
           <hr class="my-2">
 
           <dl class="row mb-0">

--- a/src/modules/gigs/travel_calculate.php
+++ b/src/modules/gigs/travel_calculate.php
@@ -47,12 +47,16 @@ $pdo->prepare(
     "UPDATE gigs SET
         car1_distance_km          = ?,
         car2_distance_km          = ?,
-        other_travel_costs_cents  = ?
+        other_travel_costs_cents  = ?,
+        car1_route_json           = ?,
+        car2_route_json           = ?
      WHERE id = ?"
 )->execute([
     $result['car1_km'],
     $result['car2_km'] ?? 0,
     (int)round($result['ferry_costs_eur'] * 100),
+    isset($result['car1_route']) ? json_encode($result['car1_route']) : null,
+    isset($result['car2_route']) ? json_encode($result['car2_route']) : null,
     $gigId,
 ]);
 

--- a/src/modules/webhook/webflow.php
+++ b/src/modules/webhook/webflow.php
@@ -281,6 +281,8 @@ function runPipelineAndCreate(PDO $pdo, array $fields, string $channel): int
         $car1Km           = $travel['car1_km'];
         $car2Km           = $travel['car2_km'] ?? 0;
         $otherTravelCents = (int)round($travel['ferry_costs_eur'] * 100);
+        $car1Route        = $travel['car1_route'] ?? null;
+        $car2Route        = $travel['car2_route'] ?? null;
     }
 
     // Price calculation.
@@ -310,5 +312,7 @@ function runPipelineAndCreate(PDO $pdo, array $fields, string $channel): int
         'car2_km'            => $car2Km,
         'other_travel_cents' => $otherTravelCents,
         'base_price_cents'   => $basePriceCents,
+        'car1_route'         => $car1Route ?? null,
+        'car2_route'         => $car2Route ?? null,
     ]), $channel);
 }


### PR DESCRIPTION
## Summary

- `RoutingHelper::waypointRouteDetail()` — new method; returns `{total_km, legs_km[]}` from the OSRM response legs array (no extra API call)
- `TravelCalculator` — all waypoints now carry labels (driver, stops, trailer, venue); `calculateFromPersonnel()` returns `car1_route` and `car2_route` arrays
- `GigCreator::create()` — stores `car1_route_json` / `car2_route_json` in INSERT
- `travel_calculate.php` — UPDATE also writes route JSON on "Recalculate travel"
- Gig detail view — collapsible "Route detail" section; shows waypoints and per-leg km; hidden when no route JSON stored (backward compat for pre-migration gigs)
- Migration 011 — adds `car1_route_json TEXT` and `car2_route_json TEXT` columns to `gigs`

## Test plan

- [ ] Apply migration 011 on dev DB
- [ ] Create a new inquiry via the AI agent form → confirm `car1_route_json` stored (check DB)
- [ ] Open gig detail page → "Route detail" link visible; expands to show waypoints + leg km
- [ ] Click "Recalculate travel" on an existing gig with venue coords → route JSON written
- [ ] Gig without venue coords → no "Route detail" section shown

## Merge notes

This branch may conflict with `feat/webflow-confirmation` in `GigCreator.php` (both touch the INSERT). The conflict is minimal: one branch adds `$status` param, the other adds route JSON columns — merge resolution is straightforward (keep both changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)