### PR TITLE
fix: geocode venue on-demand when Recalculate travel pressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `travel_calculate.php` — on-demand geocoding for legacy venues: if a venue has address/city
+  but no lat/lng (imported before inquiry pipeline existed), geocode via Nominatim on "Recalculate
+  travel", persist coords to the venue row, then run TravelCalculator normally; no-address venues
+  still show the existing warning
+
 ### Added
 - **User management UI** — `/admin/users` list, `/admin/users/new` and `/admin/users/{id}/edit`
   create/edit forms, `/admin/users/{id}/delete` soft-delete handler; owners can create musician

--- a/src/modules/gigs/travel_calculate.php
+++ b/src/modules/gigs/travel_calculate.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../../../cli/lib/TravelCalculator.php';
+require_once __DIR__ . '/../agent/lib/GeocodingHelper.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     http_response_code(405);
@@ -14,9 +15,10 @@ if (!$gigId) {
     exit;
 }
 
-// Fetch gig + venue coordinates
+// Fetch gig + venue coordinates and address fields for on-demand geocoding.
 $stmt = $pdo->prepare(
-    "SELECT g.id, v.lat, v.lng, v.distance_from_turku_km
+    "SELECT g.id, v.id AS venue_id, v.lat, v.lng, v.distance_from_turku_km,
+            v.address_line, v.city, v.name AS venue_name
      FROM   gigs g
      LEFT JOIN venues v ON v.id = g.venue_id
      WHERE  g.id = ? AND g.deleted_at IS NULL"
@@ -29,8 +31,30 @@ if (!$row) {
     exit;
 }
 
+// If venue has no coordinates, attempt on-demand geocoding from address/city/name.
+// Legacy imported gigs have address data but were never run through the inquiry pipeline.
+if (($row['lat'] === null || $row['lng'] === null) && $row['venue_id'] !== null) {
+    $geocodeQuery = trim(($row['address_line'] ?? '') . ' ' . ($row['city'] ?? ''));
+    if ($geocodeQuery === '') {
+        $geocodeQuery = trim($row['venue_name'] ?? '');
+    }
+
+    $geo = $geocodeQuery !== '' ? GeocodingHelper::geocodeVenue($geocodeQuery, '') : null;
+
+    if ($geo !== null) {
+        $row['lat'] = $geo['lat'];
+        $row['lng'] = $geo['lng'];
+        // Persist coords; update distance_from_turku_km only if not already set.
+        $pdo->prepare(
+            "UPDATE venues SET lat = ?, lng = ?,
+                distance_from_turku_km = COALESCE(distance_from_turku_km, ?)
+             WHERE id = ?"
+        )->execute([$geo['lat'], $geo['lng'], $geo['distance_km'], $row['venue_id']]);
+    }
+}
+
 if ($row['lat'] === null || $row['lng'] === null) {
-    // Venue not geocoded yet — cannot run TravelCalculator
+    // Venue has no coordinates and no address to geocode from.
     header('Location: /gigs/' . $gigId . '?error=travel_no_venue_coords');
     exit;
 }


### PR DESCRIPTION
## Summary

Legacy imported gigs have venue `address_line` / `city` populated but `lat` / `lng` null because they were never processed through the inquiry pipeline. Previously this caused a hard "no geocoordinates" error blocking travel recalculation entirely.

**Fix:** before checking for coords, if `lat`/`lng` are null and the venue has an address or city, call `GeocodingHelper::geocodeVenue()` on the spot, persist the result to the `venues` row (`COALESCE` ensures existing `distance_from_turku_km` is not overwritten), and proceed with `TravelCalculator`. If geocoding also fails (no address, Nominatim unavailable), the existing warning is shown.

## Side effects

- Legacy venue rows get `lat`/`lng` populated the first time "Recalculate travel" is pressed — no migration needed
- `distance_from_turku_km` is filled if currently null; left intact if already set

## Test plan

- [ ] Open a legacy gig with venue that has address/city but no coordinates → click "Recalculate travel" → succeeds; check venue in DB has lat/lng now set
- [ ] Gig with venue that has no address and no city → still shows warning
- [ ] Gig with already-geocoded venue → behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)