### PR TITLE
fix: TravelCalculator car assignment by person, not gig role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **TravelCalculator: car assignment now based on person, not gig role** — the previous
+  implementation used the gig role (keyboards→Car1, bass→Car2, etc.) as a proxy for which car
+  someone travels in, which broke whenever roles were assigned to non-default musicians.
+  Assignment is now driven solely by `users.transport_mode` and the new `users.default_car`
+  column (1=Car1, 2=Car2), making it independent of the musical role in the gig.
+
 ### Added
+- `db/migrations/012_users_default_car.sql` — adds `default_car TINYINT(1)` to users;
+  seeds mortti.markkanen and lauri.lehtinen as Car 2 (default_car=2)
+
+### Changed
+- `TravelCalculator::calculateFromPersonnel()` — role parameter now ignored for car assignment;
+  uses transport_mode + default_car instead; `calculate()` fetches default_car from DB
+- `process_inquiry.php`, `webflow.php` — synthetic default lineup now passes default_car from DB;
+  `$defaultRoles` map removed as it was only needed for the old role-based logic
+
+---
+
+### Added (earlier)
 - **User management UI** — `/admin/users` list, `/admin/users/new` and `/admin/users/{id}/edit`
   create/edit forms, `/admin/users/{id}/delete` soft-delete handler; owners can create musician
   and owner accounts; admin+ can also create admin accounts; developer accounts not creatable via UI

--- a/cli/lib/TravelCalculator.php
+++ b/cli/lib/TravelCalculator.php
@@ -6,29 +6,37 @@ require_once __DIR__ . '/RoutingHelper.php';
 /**
  * Computes route-based travel costs for a gig based on assigned personnel.
  *
+ * Car assignment is determined by users.transport_mode and users.default_car,
+ * NOT by the gig role. The role describes what instrument someone plays; it has
+ * no bearing on which car they travel in.
+ *
  * Canonical flows (see AGENTS.md §travel-flows):
  *
- * Car 1 (Caddy + trailer, Tuomas driving):
- *   Vilhonkatu 9 → Opettajankatu 9 (trailer, always) → [Stålarminkatu if Toni]
- *   → Puutarhakatu 18 (Alina) → Kirkkotie 2 (Joni) → Venue → reverse
+ * Car 1 (Caddy + trailer):
+ *   transport_mode='car_owner', default_car=1 → driver (Tuomas)
+ *   Trailer (Opettajankatu 9) always inserted as first stop after driver home.
+ *   Remaining Car 1 passengers picked up in query-result order.
  *
- * Car 2 (bassist, own car):
- *   Bassist home → Adolf Lindforsintie 3 (Lauri, unless local override)
- *   → [Kaarina if Valtteri assigned and not driving own car] → Venue → reverse
+ * Car 2 (own car):
+ *   transport_mode='car_owner', default_car=2 → driver (Mortti, Maxwell)
+ *   Car 2 passengers (default_car=2, not car_owner) picked up en route.
+ *
+ * Passengers:
+ *   transport_mode='passenger', default_car=1 → Car 1 stop (Toni, Alina, Joni)
+ *   transport_mode='passenger', default_car=2 → Car 2 stop (Lauri — Helsinki pickup)
+ *
+ * Local / unbilled:
+ *   transport_mode='local' (or transport_override='local') → drives own car to
+ *   venue, not billed; emits a warning and is excluded from both car routes.
+ *
+ * Per-gig overrides:
+ *   gig_personnel.transport_override, when non-null, replaces transport_mode for
+ *   that gig. default_car is always taken from users.default_car.
  *
  * Ferry: if venue.requires_ferry = 1, adds 2 × ferry_cost_estimate_cents × 2 ways.
  *
- * Role allocation:
- *   keyboards        → Car 1 driver (always Tuomas in typical lineups)
- *   drums, vocals    → Car 1 passenger
- *   guitar           → Car 2 pickup from home (Lauri, Helsinki); skip if transport_override='local'
- *   bass             → Car 2 driver
- *   sound_engineering → transport_mode='passenger' → Car 1 (Toni)
- *                       transport_mode='car_owner'  → Car 2 pickup (Valtteri default)
- *                       transport_override='car_owner' → drives own car (not billed; warning emitted)
- *
  * All km values are one-way route × 2 (round trip approximation).
- * Manual override: owner edits car1_distance_km / car2_distance_km on the gig form after calculation.
+ * Manual override: owner edits car1_distance_km / car2_distance_km on the gig form.
  */
 class TravelCalculator
 {
@@ -36,10 +44,6 @@ class TravelCalculator
     // Pre-geocoded from Nominatim. Update if storage location changes.
     private const TRAILER_LAT = 60.4481;
     private const TRAILER_LNG = 22.2547;
-
-    // Turku city centre reference (matches GeocodingHelper)
-    private const TURKU_LAT = 60.4518;
-    private const TURKU_LNG = 22.2666;
 
     /**
      * Calculate travel costs using personnel assigned to the gig in the database.
@@ -54,7 +58,7 @@ class TravelCalculator
     {
         $stmt = $pdo->prepare(
             "SELECT gp.role, gp.transport_override,
-                    u.username, u.home_lat, u.home_lng, u.transport_mode
+                    u.username, u.home_lat, u.home_lng, u.transport_mode, u.default_car
              FROM   gig_personnel gp
              JOIN   users u ON u.id = gp.user_id
              WHERE  gp.gig_id = ?"
@@ -71,7 +75,10 @@ class TravelCalculator
      * Calculate travel costs with an explicit personnel array (used at agent inquiry time
      * before gig_personnel rows exist).
      *
-     * @param  array  $personnel  Rows shaped like the gig_personnel JOIN users query above.
+     * Each element must have:
+     *   username, home_lat, home_lng, transport_mode, default_car, transport_override, role
+     *
+     * @param  array  $personnel
      * @param  float  $venueLat
      * @param  float  $venueLng
      * @param  array{requires_ferry: bool, cost_eur: float}  $ferry
@@ -85,78 +92,60 @@ class TravelCalculator
     ): array {
         $warnings   = [];
         $car1Driver = null;   // [lat, lng]
-        $car1Stops  = [];     // ordered waypoints added between driver home and venue
+        $car1Stops  = [];     // ordered pickup waypoints for Car 1
         $car2Driver = null;   // [lat, lng]
-        $car2Stops  = [];     // ordered waypoints added between driver home and venue
+        $car2Stops  = [];     // ordered pickup waypoints for Car 2
 
         foreach ($personnel as $p) {
-            $effectiveMode     = $p['transport_override'] ?? $p['transport_mode'];
-            $lat               = isset($p['home_lat']) ? (float)$p['home_lat'] : null;
-            $lng               = isset($p['home_lng']) ? (float)$p['home_lng'] : null;
-            $hasCoords         = ($lat !== null && $lng !== null);
+            // transport_override on the gig row overrides the user-level transport_mode.
+            // default_car always comes from the user, never from the gig.
+            $effectiveMode = $p['transport_override'] ?? $p['transport_mode'];
+            $defaultCar    = (int)($p['default_car'] ?? 1);
 
-            switch ($p['role']) {
-                case 'keyboards':
-                    // Car 1 driver — always Tuomas
-                    if (!$hasCoords) {
-                        $warnings[] = "Car 1 driver ({$p['username']}) has no home coordinates — Car 1 route unavailable.";
-                    } else {
-                        $car1Driver = [$lat, $lng];
-                    }
-                    break;
+            $lat       = isset($p['home_lat']) ? (float)$p['home_lat'] : null;
+            $lng       = isset($p['home_lng']) ? (float)$p['home_lng'] : null;
+            $hasCoords = ($lat !== null && $lng !== null);
 
-                case 'drums':
-                case 'vocals':
-                    // Always Car 1 passenger (Joni, Alina — Turku-based)
-                    if ($hasCoords) {
-                        $car1Stops[] = [$lat, $lng];
-                    } else {
-                        $warnings[] = "{$p['username']} ({$p['role']}) has no home coordinates — pickup waypoint skipped.";
-                    }
-                    break;
+            if ($effectiveMode === 'local') {
+                // Drives own car to venue, not billed. No pickup.
+                $warnings[] = "{$p['username']} drives own car (local) — excluded from Car 1 and Car 2 routes.";
+                continue;
+            }
 
-                case 'guitar':
-                    // Car 2 pickup (Lauri, Helsinki) — unless locally overridden
-                    if ($effectiveMode === 'local') {
-                        // Already at or near venue area; no pickup needed
-                        break;
-                    }
-                    if ($hasCoords) {
-                        $car2Stops[] = [$lat, $lng];
-                    } else {
-                        $warnings[] = "{$p['username']} (guitar) has no home coordinates — Car 2 pickup skipped.";
-                    }
-                    break;
-
-                case 'bass':
-                    // Car 2 driver
+            if ($effectiveMode === 'car_owner') {
+                // This person drives a band car.
+                if ($defaultCar === 2) {
+                    // Car 2 driver (Mortti, Maxwell).
                     if (!$hasCoords) {
                         $warnings[] = "Car 2 driver ({$p['username']}) has no home coordinates — Car 2 route unavailable.";
                     } else {
                         $car2Driver = [$lat, $lng];
                     }
-                    break;
-
-                case 'sound_engineering':
-                    if ($effectiveMode === 'car_owner') {
-                        // Drives own car (Valtteri when override set, or explicit own-car flag)
-                        $warnings[] = "{$p['username']} (sound engineering) drives own car — not billed in Car 1 or Car 2.";
-                    } elseif ($effectiveMode === 'passenger') {
-                        // Car 1 passenger (Toni — Turku-based passenger)
-                        if ($hasCoords) {
-                            $car1Stops[] = [$lat, $lng];
-                        } else {
-                            $warnings[] = "{$p['username']} (sound engineering, Car 1) has no home coordinates — pickup waypoint skipped.";
-                        }
+                } else {
+                    // Car 1 driver (Tuomas).
+                    if (!$hasCoords) {
+                        $warnings[] = "Car 1 driver ({$p['username']}) has no home coordinates — Car 1 route unavailable.";
                     } else {
-                        // car_owner without override = Car 2 pickup (Valtteri typical case)
-                        if ($hasCoords) {
-                            $car2Stops[] = [$lat, $lng];
-                        } else {
-                            $warnings[] = "{$p['username']} (sound engineering, Car 2 pickup) has no home coordinates — waypoint skipped.";
-                        }
+                        $car1Driver = [$lat, $lng];
                     }
-                    break;
+                }
+            } else {
+                // Passenger (transport_mode='passenger' or public_transport or unrecognised value).
+                if ($defaultCar === 2) {
+                    // Travels with Car 2; picked up en route (e.g. Lauri from Helsinki).
+                    if ($hasCoords) {
+                        $car2Stops[] = [$lat, $lng];
+                    } else {
+                        $warnings[] = "{$p['username']} (Car 2 passenger) has no home coordinates — pickup waypoint skipped.";
+                    }
+                } else {
+                    // Travels with Car 1 (default).
+                    if ($hasCoords) {
+                        $car1Stops[] = [$lat, $lng];
+                    } else {
+                        $warnings[] = "{$p['username']} (Car 1 passenger) has no home coordinates — pickup waypoint skipped.";
+                    }
+                }
             }
         }
 

--- a/db/migrations/012_users_default_car.sql
+++ b/db/migrations/012_users_default_car.sql
@@ -1,0 +1,17 @@
+-- Migration 012: add default_car to users
+-- Encodes which band car a person defaults to.
+-- Used by TravelCalculator to determine driver vs passenger assignment
+-- independently of the gig role they happen to be assigned.
+--
+-- Values: 1 = Car 1 (Caddy, Tuomas driving), 2 = Car 2 (own car, Mortti/Maxwell driving)
+-- Default is 1 because most musicians ride in Car 1.
+
+ALTER TABLE users
+  ADD COLUMN default_car TINYINT(1) UNSIGNED NOT NULL DEFAULT 1
+    COMMENT '1=Car 1 (Caddy), 2=Car 2. Used by TravelCalculator; independent of gig role.';
+
+-- Seed correct values for known musicians.
+-- Car 2: Mortti (driver) and Lauri (Helsinki pickup, rides with Car 2 driver).
+UPDATE users SET default_car = 2
+WHERE username IN ('mortti.markkanen', 'lauri.lehtinen')
+  AND deleted_at IS NULL;

--- a/db/schema/core.sql
+++ b/db/schema/core.sql
@@ -284,9 +284,14 @@ CREATE TABLE IF NOT EXISTS users (
     home_address   VARCHAR(255)           DEFAULT NULL,
     home_lat       DECIMAL(9,6)           DEFAULT NULL,
     home_lng       DECIMAL(9,6)           DEFAULT NULL,
-    -- transport_mode: car_owner = has own vehicle; passenger = always needs a lift
+    -- transport_mode: car_owner = drives a billed band car; passenger = needs a lift; local = own car, unbilled
     transport_mode ENUM('car_owner','passenger','public_transport')
                                  NOT NULL DEFAULT 'passenger',
+    -- default_car: which band car this person belongs to by default (1=Caddy/Car1, 2=Car2).
+    -- car_owner with default_car=1 → Car 1 driver (Tuomas); default_car=2 → Car 2 driver (Mortti/Maxwell).
+    -- passenger with default_car=1 → Car 1 stop; default_car=2 → Car 2 pickup (e.g. Lauri, Helsinki).
+    -- Gig-level overrides go on gig_personnel.transport_override.
+    default_car    TINYINT(1) UNSIGNED NOT NULL DEFAULT 1,
     password_hash  VARCHAR(255)  NOT NULL,
     role           ENUM(
                        'developer',

--- a/src/modules/agent/process_inquiry.php
+++ b/src/modules/agent/process_inquiry.php
@@ -86,30 +86,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             'tuomas.lundberg', 'toni.puttonen', 'joni.virtanen',
             'alina.kangas', 'lauri.lehtinen', 'mortti.markkanen',
         ];
-        // Role assignments for synthetic default lineup
-        $defaultRoles = [
-            'tuomas.lundberg' => 'keyboards',
-            'toni.puttonen'   => 'sound_engineering',
-            'joni.virtanen'   => 'drums',
-            'alina.kangas'    => 'vocals',
-            'lauri.lehtinen'  => 'guitar',
-            'mortti.markkanen'=> 'bass',
-        ];
         $placeholders = implode(',', array_fill(0, count($defaultUsernames), '?'));
         $userStmt = $pdo->prepare(
-            "SELECT username, home_lat, home_lng, transport_mode
+            "SELECT username, home_lat, home_lng, transport_mode, default_car
              FROM   users WHERE username IN ($placeholders) AND deleted_at IS NULL"
         );
         $userStmt->execute($defaultUsernames);
         $defaultUsers = $userStmt->fetchAll(PDO::FETCH_ASSOC);
 
         $synthPersonnel = array_map(fn($u) => [
-            'role'               => $defaultRoles[$u['username']] ?? 'other',
+            'role'               => 'other', // role is irrelevant; transport_mode + default_car drive assignment
             'transport_override' => null,
             'username'           => $u['username'],
             'home_lat'           => $u['home_lat'],
             'home_lng'           => $u['home_lng'],
             'transport_mode'     => $u['transport_mode'],
+            'default_car'        => $u['default_car'],
         ], $defaultUsers);
 
         $travel = TravelCalculator::calculateFromPersonnel(

--- a/src/modules/webhook/webflow.php
+++ b/src/modules/webhook/webflow.php
@@ -252,29 +252,22 @@ function runPipelineAndCreate(PDO $pdo, array $fields, string $channel): int
             'tuomas.lundberg', 'toni.puttonen', 'joni.virtanen',
             'alina.kangas', 'lauri.lehtinen', 'mortti.markkanen',
         ];
-        $defaultRoles = [
-            'tuomas.lundberg'  => 'keyboards',
-            'toni.puttonen'    => 'sound_engineering',
-            'joni.virtanen'    => 'drums',
-            'alina.kangas'     => 'vocals',
-            'lauri.lehtinen'   => 'guitar',
-            'mortti.markkanen' => 'bass',
-        ];
         $placeholders = implode(',', array_fill(0, count($defaultUsernames), '?'));
         $userStmt = $pdo->prepare(
-            "SELECT username, home_lat, home_lng, transport_mode
+            "SELECT username, home_lat, home_lng, transport_mode, default_car
              FROM   users WHERE username IN ($placeholders) AND deleted_at IS NULL"
         );
         $userStmt->execute($defaultUsernames);
         $defaultUsers = $userStmt->fetchAll(PDO::FETCH_ASSOC);
 
         $synthPersonnel = array_map(fn($u) => [
-            'role'               => $defaultRoles[$u['username']] ?? 'other',
+            'role'               => 'other', // role is irrelevant; transport_mode + default_car drive assignment
             'transport_override' => null,
             'username'           => $u['username'],
             'home_lat'           => $u['home_lat'],
             'home_lng'           => $u['home_lng'],
             'transport_mode'     => $u['transport_mode'],
+            'default_car'        => $u['default_car'],
         ], $defaultUsers);
 
         $travel = TravelCalculator::calculateFromPersonnel($synthPersonnel, $venueLat, $venueLng);


### PR DESCRIPTION
## Summary

The previous implementation assigned cars based on gig role (keyboards→Car1 driver, bass→Car2 driver, guitar→Car2 passenger, etc.). This is a semantic error: the role describes what instrument someone plays, not how they travel to the gig. It happened to produce correct results in practice only because Tuomas almost always plays keyboards and Mortti almost always plays bass.

**Fix:** car assignment is now driven by `users.transport_mode` + new `users.default_car` column:

| transport_mode | default_car | Result |
|---|---|---|
| `car_owner` | 1 | Car 1 driver (Tuomas) |
| `car_owner` | 2 | Car 2 driver (Mortti, Maxwell) |
| `passenger` | 1 | Car 1 stop (Toni, Alina, Joni) |
| `passenger` | 2 | Car 2 stop/pickup (Lauri — Helsinki) |
| `local` | any | Drives own car, unbilled, excluded from routes |

Migration 012 adds `default_car TINYINT(1) UNSIGNED NOT NULL DEFAULT 1` to `users` and seeds `mortti.markkanen` and `lauri.lehtinen` as `default_car=2`.

## Callers updated

- `TravelCalculator::calculate()` — fetches `u.default_car` from DB
- `TravelCalculator::calculateFromPersonnel()` — fully rewrites the role switch to transport_mode+default_car logic
- `process_inquiry.php`, `webflow.php` — synthetic default lineup passes `default_car` from DB; `$defaultRoles` map removed

## Test plan

- [ ] Apply migration 012
- [ ] With the standard lineup (Tuomas/keyboards, Mortti/bass, etc.): recalculate travel on any gig → same result as before (roles match the defaults)
- [ ] Swap roles (e.g. assign Lauri as keyboards, Toni as bass): recalculate → Car 1 driver is still Tuomas (car_owner, default_car=1), Car 2 driver is still Mortti (car_owner, default_car=2); Lauri (passenger, default_car=2) rides with Car 2 regardless of his gig role
- [ ] Assign Tuomas as sound_engineering: he is still Car 1 driver (transport_mode=car_owner, default_car=1)

## Note on Joni's 3.8 km leg

Separately from this fix, Joni's home coordinates appear to be geocoded to somewhere in central Turku (~3.8 km from the trailer) rather than his actual address. Check `home_lat`/`home_lng` for `joni.virtanen` in the DB and re-geocode if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)