### PR TITLE
Release: route transparency, person-based travel, webflow confirmation, geocoding fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- **Valtteri's transport_mode corrected to passenger/Car2** — was set to `car_owner`
+  under old role-based semantics; under the new person-based model this incorrectly made
+  him Car 1 driver and silently dropped the real Car 1 driver from the route. Now
+  `passenger` + `default_car=2`; gig-level override remains `transport_override='local'`
+  when he drives himself. Migration 013 updates the live row; musician_addresses.sql updated
+  to match.
+- **TravelCalculator: warn on duplicate car driver assignment** — previously the last
+  `car_owner` processed for a given car slot silently overwrote the first, causing the
+  real driver to vanish from the route with no indication. Now first-wins and a warning
+  is emitted for the duplicate.
 - **TravelCalculator: car assignment now based on person, not gig role** — the previous
   implementation used the gig role (keyboards→Car1, bass→Car2, etc.) as a proxy for which car
   someone travels in, which broke whenever roles were assigned to non-default musicians.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- **TravelCalculator: `transport_override='car_owner'` treated as `local`** — schema
+  documents this override as "drives own non-band car this gig, not billed"; previously
+  the code incorrectly treated it as a band car driver assignment; now normalised to
+  `local` before the mode switch so it is excluded from both car routes
+- **TravelCalculator: `public_transport` users excluded from pickup routes** — were
+  silently falling into the passenger branch and receiving band car pickup waypoints;
+  now skipped (no warning, expected independent travel)
+- **TravelCalculator: warn when Car 2 passengers have no driver** — previously these
+  personnel were silently dropped; now a named warning lists the affected passengers
 - **Valtteri's transport_mode corrected to passenger/Car2** — was set to `car_owner`
   under old role-based semantics; under the new person-based model this incorrectly made
   him Car 1 driver and silently dropped the real Car 1 driver from the route. Now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **TravelCalculator: `public_transport` users excluded from pickup routes** — were
   silently falling into the passenger branch and receiving band car pickup waypoints;
   now skipped (no warning, expected independent travel)
-- **TravelCalculator: warn when Car 2 passengers have no driver** — previously these
-  personnel were silently dropped; now a named warning lists the affected passengers
+- **TravelCalculator: Car 2 passengers fall back to Car 1 when no Car 2 driver** —
+  previously silently dropped from the route; now merged into Car 1 stops with a
+  warning; Car 1 (Caddy) has capacity for the full lineup
 - **Valtteri's transport_mode corrected to passenger/Car2** — was set to `car_owner`
   under old role-based semantics; under the new person-based model this incorrectly made
   him Car 1 driver and silently dropped the real Car 1 driver from the route. Now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Tilauslomake gigs created with `status=confirmed`** — booking confirmation form semantically
+  maps to confirmed, not inquiry; `GigCreator::create()` now accepts an optional `$status` param
+  (default `'inquiry'`); Tilauslomake handler passes `'confirmed'`
+- **Webflow payload preserved in `order_description`** — Tilauslomake builds a concise summary
+  string (`Tilauslomake – {date} – {customer}`); Email Form falls back raw message text if AI
+  extraction leaves `order_description` empty
+
+### Changed
+- `GigCreator::create()` — added optional `$status` parameter (default `'inquiry'`); validates
+  against the full `gigs.status` ENUM; replaces hard-coded `'inquiry'` literal in INSERT
+
+---
+
+### Added (previous)
 - **User management UI** — `/admin/users` list, `/admin/users/new` and `/admin/users/{id}/edit`
   create/edit forms, `/admin/users/{id}/delete` soft-delete handler; owners can create musician
   and owner accounts; admin+ can also create admin accounts; developer accounts not creatable via UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Route calculation transparency** — TravelCalculator now returns labelled waypoints and
+  per-leg km for each car route; stored as `car1_route_json` / `car2_route_json` (TEXT) on the
+  `gigs` row; gig detail view shows a collapsible "Route detail" table with waypoints and leg
+  distances; "Recalculate travel" also writes route JSON on recalculation
+- `db/migrations/011_route_json.sql` — adds `car1_route_json` and `car2_route_json` columns
+
+### Changed
+- `RoutingHelper::waypointRouteKm()` — delegates to new `waypointRouteDetail()` (no behaviour change)
+- `RoutingHelper::waypointRouteDetail()` — new method; returns `{total_km, legs_km[]}` from OSRM
+- `TravelCalculator::calculateFromPersonnel()` — now returns `car1_route` and `car2_route` arrays
+  alongside existing keys; all waypoints carry labels for display
+- `GigCreator::create()` — includes `car1_route_json` / `car2_route_json` in INSERT
+- `src/modules/gigs/travel_calculate.php` — UPDATE writes route JSON on recalculation
+
+---
+
+### Added (previous)
 - **User management UI** — `/admin/users` list, `/admin/users/new` and `/admin/users/{id}/edit`
   create/edit forms, `/admin/users/{id}/delete` soft-delete handler; owners can create musician
   and owner accounts; admin+ can also create admin accounts; developer accounts not creatable via UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **TravelCalculator: car assignment now based on person, not gig role** — the previous
+  implementation used the gig role (keyboards→Car1, bass→Car2, etc.) as a proxy for which car
+  someone travels in, which broke whenever roles were assigned to non-default musicians.
+  Assignment is now driven solely by `users.transport_mode` and the new `users.default_car`
+  column (1=Car1, 2=Car2), making it independent of the musical role in the gig.
+
 ### Added
+- `db/migrations/012_users_default_car.sql` — adds `default_car TINYINT(1)` to users;
+  seeds mortti.markkanen and lauri.lehtinen as Car 2 (default_car=2)
+
+### Changed
+- `TravelCalculator::calculateFromPersonnel()` — role parameter now ignored for car assignment;
+  uses transport_mode + default_car instead; `calculate()` fetches default_car from DB
+- `process_inquiry.php`, `webflow.php` — synthetic default lineup now passes default_car from DB;
+  `$defaultRoles` map removed as it was only needed for the old role-based logic
+
+---
+
+### Added (earlier)
 - **User management UI** — `/admin/users` list, `/admin/users/new` and `/admin/users/{id}/edit`
   create/edit forms, `/admin/users/{id}/delete` soft-delete handler; owners can create musician
   and owner accounts; admin+ can also create admin accounts; developer accounts not creatable via UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `travel_calculate.php` — on-demand geocoding for legacy venues: if a venue has address/city
+  but no lat/lng (imported before inquiry pipeline existed), geocode via Nominatim on "Recalculate
+  travel", persist coords to the venue row, then run TravelCalculator normally; no-address venues
+  still show the existing warning
+
 ### Added
 - **User management UI** — `/admin/users` list, `/admin/users/new` and `/admin/users/{id}/edit`
   create/edit forms, `/admin/users/{id}/delete` soft-delete handler; owners can create musician

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,16 @@ Stack: PHP 8.2 + Apache · MariaDB 10.11 · Vue 3 + Bootstrap 5 · Docker
 
 ---
 
+## Branch strategy
+
+- `main` — production; only receives PRs from `dev`
+- `dev` — integration branch; receives PRs from feature branches
+- `feat/<topic>` — all new work; branched from `dev`, merged back to `dev` via PR
+- Hotfixes: `fix/<topic>` branched from `dev` (or `main` if truly urgent)
+- **Never commit new features directly to `dev` or `main`**
+
+---
+
 ## Workflow rules
 
 - **Always ask** before introducing a new architectural pattern or dependency

--- a/cli/lib/RoutingHelper.php
+++ b/cli/lib/RoutingHelper.php
@@ -61,6 +61,18 @@ class RoutingHelper
      */
     public static function waypointRouteKm(array $waypoints): ?float
     {
+        $detail = self::waypointRouteDetail($waypoints);
+        return $detail !== null ? $detail['total_km'] : null;
+    }
+
+    /**
+     * Compute total and per-leg driving distances for an ordered sequence of waypoints via OSRM.
+     *
+     * @param  array<array{float, float}> $waypoints  Each element: [lat, lng]. Min 2.
+     * @return array{total_km: float, legs_km: float[]}|null  null on failure.
+     */
+    public static function waypointRouteDetail(array $waypoints): ?array
+    {
         if (count($waypoints) < 2) {
             return null;
         }
@@ -88,6 +100,13 @@ class RoutingHelper
         if (($data['code'] ?? '') !== 'Ok' || empty($data['routes'][0]['distance'])) {
             return null;
         }
-        return round($data['routes'][0]['distance'] / 1000, 1);
+
+        $totalKm = round($data['routes'][0]['distance'] / 1000, 1);
+        $legsKm  = array_map(
+            fn($leg) => round(($leg['distance'] ?? 0) / 1000, 1),
+            $data['routes'][0]['legs'] ?? []
+        );
+
+        return ['total_km' => $totalKm, 'legs_km' => $legsKm];
     }
 }

--- a/cli/lib/TravelCalculator.php
+++ b/cli/lib/TravelCalculator.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/RoutingHelper.php';
  * NOT by the gig role. The role describes what instrument someone plays; it has
  * no bearing on which car they travel in.
  *
- * Canonical flows (see AGENTS.md §travel-flows):
+ * Canonical flows:
  *
  * Car 1 (Caddy + trailer):
  *   transport_mode='car_owner', default_car=1 → driver (Tuomas)
@@ -100,7 +100,17 @@ class TravelCalculator
         foreach ($personnel as $p) {
             // transport_override on the gig row overrides the user-level transport_mode.
             // default_car always comes from the user, never from the gig.
-            $effectiveMode = $p['transport_override'] ?? $p['transport_mode'];
+            $overrideMode  = $p['transport_override'];
+            $baseMode      = $p['transport_mode'];
+            $effectiveMode = $overrideMode ?? $baseMode;
+
+            // transport_override='car_owner' means "drives own non-band car this gig, not billed"
+            // (distinct from transport_mode='car_owner' = designated band car driver).
+            // Normalise to 'local' so the exclusion logic below handles both identically.
+            if ($overrideMode === 'car_owner') {
+                $effectiveMode = 'local';
+            }
+
             $defaultCar    = (int)($p['default_car'] ?? 1);
 
             $lat       = isset($p['home_lat']) ? (float)$p['home_lat'] : null;
@@ -110,6 +120,11 @@ class TravelCalculator
             if ($effectiveMode === 'local') {
                 // Drives own car to venue, not billed. No pickup.
                 $warnings[] = "{$p['username']} drives own car (local) — excluded from Car 1 and Car 2 routes.";
+                continue;
+            }
+
+            if ($effectiveMode === 'public_transport') {
+                // Travels independently by train/bus; no band car pickup needed or billed.
                 continue;
             }
 
@@ -164,6 +179,10 @@ class TravelCalculator
         }
         if ($car2Driver !== null && $car2Km === null) {
             $warnings[] = 'Car 2 OSRM routing failed — check network and waypoint coordinates.';
+        }
+        if ($car2Driver === null && !empty($car2Stops)) {
+            $stopNames = implode(', ', array_column($car2Stops, 'label'));
+            $warnings[] = "Car 2 passenger(s) have no driver — not included in any route: $stopNames. Add a Car 2 driver or set transport_override='local'.";
         }
 
         $ferryCosts = 0.0;

--- a/cli/lib/TravelCalculator.php
+++ b/cli/lib/TravelCalculator.php
@@ -117,14 +117,18 @@ class TravelCalculator
                 // This person drives a band car.
                 if ($defaultCar === 2) {
                     // Car 2 driver (Mortti, Maxwell).
-                    if (!$hasCoords) {
+                    if ($car2Driver !== null) {
+                        $warnings[] = "Duplicate Car 2 driver: {$p['username']} ignored — {$car2Driver['label']} already assigned. Check users.default_car and transport_mode.";
+                    } elseif (!$hasCoords) {
                         $warnings[] = "Car 2 driver ({$p['username']}) has no home coordinates — Car 2 route unavailable.";
                     } else {
                         $car2Driver = ['lat' => $lat, 'lng' => $lng, 'label' => "{$p['username']} (Car 2 driver)"];
                     }
                 } else {
                     // Car 1 driver (Tuomas).
-                    if (!$hasCoords) {
+                    if ($car1Driver !== null) {
+                        $warnings[] = "Duplicate Car 1 driver: {$p['username']} ignored — {$car1Driver['label']} already assigned. Check users.default_car and transport_mode.";
+                    } elseif (!$hasCoords) {
                         $warnings[] = "Car 1 driver ({$p['username']}) has no home coordinates — Car 1 route unavailable.";
                     } else {
                         $car1Driver = ['lat' => $lat, 'lng' => $lng, 'label' => "{$p['username']} (Car 1 driver)"];

--- a/cli/lib/TravelCalculator.php
+++ b/cli/lib/TravelCalculator.php
@@ -181,8 +181,13 @@ class TravelCalculator
             $warnings[] = 'Car 2 OSRM routing failed — check network and waypoint coordinates.';
         }
         if ($car2Driver === null && !empty($car2Stops)) {
+            // No Car 2 driver in lineup: fall back these passengers to Car 1.
+            // Car 1 (Caddy) has capacity; this handles any lineup that omits Mortti/Maxwell.
+            // Owner can override per-person with transport_override='local' if they drive themselves.
             $stopNames = implode(', ', array_column($car2Stops, 'label'));
-            $warnings[] = "Car 2 passenger(s) have no driver — not included in any route: $stopNames. Add a Car 2 driver or set transport_override='local'.";
+            $warnings[] = "No Car 2 driver in lineup — Car 2 passenger(s) added to Car 1 route: $stopNames.";
+            $car1Stops = array_merge($car1Stops, $car2Stops);
+            $car2Stops = [];
         }
 
         $ferryCosts = 0.0;

--- a/cli/lib/TravelCalculator.php
+++ b/cli/lib/TravelCalculator.php
@@ -6,29 +6,37 @@ require_once __DIR__ . '/RoutingHelper.php';
 /**
  * Computes route-based travel costs for a gig based on assigned personnel.
  *
+ * Car assignment is determined by users.transport_mode and users.default_car,
+ * NOT by the gig role. The role describes what instrument someone plays; it has
+ * no bearing on which car they travel in.
+ *
  * Canonical flows (see AGENTS.md §travel-flows):
  *
- * Car 1 (Caddy + trailer, Tuomas driving):
- *   Vilhonkatu 9 → Opettajankatu 9 (trailer, always) → [Stålarminkatu if Toni]
- *   → Puutarhakatu 18 (Alina) → Kirkkotie 2 (Joni) → Venue → reverse
+ * Car 1 (Caddy + trailer):
+ *   transport_mode='car_owner', default_car=1 → driver (Tuomas)
+ *   Trailer (Opettajankatu 9) always inserted as first stop after driver home.
+ *   Remaining Car 1 passengers picked up in query-result order.
  *
- * Car 2 (bassist, own car):
- *   Bassist home → Adolf Lindforsintie 3 (Lauri, unless local override)
- *   → [Kaarina if Valtteri assigned and not driving own car] → Venue → reverse
+ * Car 2 (own car):
+ *   transport_mode='car_owner', default_car=2 → driver (Mortti, Maxwell)
+ *   Car 2 passengers (default_car=2, not car_owner) picked up en route.
+ *
+ * Passengers:
+ *   transport_mode='passenger', default_car=1 → Car 1 stop (Toni, Alina, Joni)
+ *   transport_mode='passenger', default_car=2 → Car 2 stop (Lauri — Helsinki pickup)
+ *
+ * Local / unbilled:
+ *   transport_mode='local' (or transport_override='local') → drives own car to
+ *   venue, not billed; emits a warning and is excluded from both car routes.
+ *
+ * Per-gig overrides:
+ *   gig_personnel.transport_override, when non-null, replaces transport_mode for
+ *   that gig. default_car is always taken from users.default_car.
  *
  * Ferry: if venue.requires_ferry = 1, adds 2 × ferry_cost_estimate_cents × 2 ways.
  *
- * Role allocation:
- *   keyboards        → Car 1 driver (always Tuomas in typical lineups)
- *   drums, vocals    → Car 1 passenger
- *   guitar           → Car 2 pickup from home (Lauri, Helsinki); skip if transport_override='local'
- *   bass             → Car 2 driver
- *   sound_engineering → transport_mode='passenger' → Car 1 (Toni)
- *                       transport_mode='car_owner'  → Car 2 pickup (Valtteri default)
- *                       transport_override='car_owner' → drives own car (not billed; warning emitted)
- *
  * All km values are one-way route × 2 (round trip approximation).
- * Manual override: owner edits car1_distance_km / car2_distance_km on the gig form after calculation.
+ * Manual override: owner edits car1_distance_km / car2_distance_km on the gig form.
  */
 class TravelCalculator
 {
@@ -36,10 +44,6 @@ class TravelCalculator
     // Pre-geocoded from Nominatim. Update if storage location changes.
     private const TRAILER_LAT = 60.4481;
     private const TRAILER_LNG = 22.2547;
-
-    // Turku city centre reference (matches GeocodingHelper)
-    private const TURKU_LAT = 60.4518;
-    private const TURKU_LNG = 22.2666;
 
     /**
      * Calculate travel costs using personnel assigned to the gig in the database.
@@ -54,7 +58,7 @@ class TravelCalculator
     {
         $stmt = $pdo->prepare(
             "SELECT gp.role, gp.transport_override,
-                    u.username, u.home_lat, u.home_lng, u.transport_mode
+                    u.username, u.home_lat, u.home_lng, u.transport_mode, u.default_car
              FROM   gig_personnel gp
              JOIN   users u ON u.id = gp.user_id
              WHERE  gp.gig_id = ?"
@@ -71,7 +75,10 @@ class TravelCalculator
      * Calculate travel costs with an explicit personnel array (used at agent inquiry time
      * before gig_personnel rows exist).
      *
-     * @param  array  $personnel  Rows shaped like the gig_personnel JOIN users query above.
+     * Each element must have:
+     *   username, home_lat, home_lng, transport_mode, default_car, transport_override, role
+     *
+     * @param  array  $personnel
      * @param  float  $venueLat
      * @param  float  $venueLng
      * @param  array{requires_ferry: bool, cost_eur: float}  $ferry
@@ -85,78 +92,60 @@ class TravelCalculator
     ): array {
         $warnings   = [];
         $car1Driver = null;   // [lat, lng]
-        $car1Stops  = [];     // ordered waypoints added between driver home and venue
+        $car1Stops  = [];     // ordered pickup waypoints for Car 1
         $car2Driver = null;   // [lat, lng]
-        $car2Stops  = [];     // ordered waypoints added between driver home and venue
+        $car2Stops  = [];     // ordered pickup waypoints for Car 2
 
         foreach ($personnel as $p) {
-            $effectiveMode     = $p['transport_override'] ?? $p['transport_mode'];
-            $lat               = isset($p['home_lat']) ? (float)$p['home_lat'] : null;
-            $lng               = isset($p['home_lng']) ? (float)$p['home_lng'] : null;
-            $hasCoords         = ($lat !== null && $lng !== null);
+            // transport_override on the gig row overrides the user-level transport_mode.
+            // default_car always comes from the user, never from the gig.
+            $effectiveMode = $p['transport_override'] ?? $p['transport_mode'];
+            $defaultCar    = (int)($p['default_car'] ?? 1);
 
-            switch ($p['role']) {
-                case 'keyboards':
-                    // Car 1 driver — always Tuomas
-                    if (!$hasCoords) {
-                        $warnings[] = "Car 1 driver ({$p['username']}) has no home coordinates — Car 1 route unavailable.";
-                    } else {
-                        $car1Driver = [$lat, $lng];
-                    }
-                    break;
+            $lat       = isset($p['home_lat']) ? (float)$p['home_lat'] : null;
+            $lng       = isset($p['home_lng']) ? (float)$p['home_lng'] : null;
+            $hasCoords = ($lat !== null && $lng !== null);
 
-                case 'drums':
-                case 'vocals':
-                    // Always Car 1 passenger (Joni, Alina — Turku-based)
-                    if ($hasCoords) {
-                        $car1Stops[] = [$lat, $lng];
-                    } else {
-                        $warnings[] = "{$p['username']} ({$p['role']}) has no home coordinates — pickup waypoint skipped.";
-                    }
-                    break;
+            if ($effectiveMode === 'local') {
+                // Drives own car to venue, not billed. No pickup.
+                $warnings[] = "{$p['username']} drives own car (local) — excluded from Car 1 and Car 2 routes.";
+                continue;
+            }
 
-                case 'guitar':
-                    // Car 2 pickup (Lauri, Helsinki) — unless locally overridden
-                    if ($effectiveMode === 'local') {
-                        // Already at or near venue area; no pickup needed
-                        break;
-                    }
-                    if ($hasCoords) {
-                        $car2Stops[] = [$lat, $lng];
-                    } else {
-                        $warnings[] = "{$p['username']} (guitar) has no home coordinates — Car 2 pickup skipped.";
-                    }
-                    break;
-
-                case 'bass':
-                    // Car 2 driver
+            if ($effectiveMode === 'car_owner') {
+                // This person drives a band car.
+                if ($defaultCar === 2) {
+                    // Car 2 driver (Mortti, Maxwell).
                     if (!$hasCoords) {
                         $warnings[] = "Car 2 driver ({$p['username']}) has no home coordinates — Car 2 route unavailable.";
                     } else {
                         $car2Driver = [$lat, $lng];
                     }
-                    break;
-
-                case 'sound_engineering':
-                    if ($effectiveMode === 'car_owner') {
-                        // Drives own car (Valtteri when override set, or explicit own-car flag)
-                        $warnings[] = "{$p['username']} (sound engineering) drives own car — not billed in Car 1 or Car 2.";
-                    } elseif ($effectiveMode === 'passenger') {
-                        // Car 1 passenger (Toni — Turku-based passenger)
-                        if ($hasCoords) {
-                            $car1Stops[] = [$lat, $lng];
-                        } else {
-                            $warnings[] = "{$p['username']} (sound engineering, Car 1) has no home coordinates — pickup waypoint skipped.";
-                        }
+                } else {
+                    // Car 1 driver (Tuomas).
+                    if (!$hasCoords) {
+                        $warnings[] = "Car 1 driver ({$p['username']}) has no home coordinates — Car 1 route unavailable.";
                     } else {
-                        // car_owner without override = Car 2 pickup (Valtteri typical case)
-                        if ($hasCoords) {
-                            $car2Stops[] = [$lat, $lng];
-                        } else {
-                            $warnings[] = "{$p['username']} (sound engineering, Car 2 pickup) has no home coordinates — waypoint skipped.";
-                        }
+                        $car1Driver = [$lat, $lng];
                     }
-                    break;
+                }
+            } else {
+                // Passenger (transport_mode='passenger' or public_transport or unrecognised value).
+                if ($defaultCar === 2) {
+                    // Travels with Car 2; picked up en route (e.g. Lauri from Helsinki).
+                    if ($hasCoords) {
+                        $car2Stops[] = [$lat, $lng];
+                    } else {
+                        $warnings[] = "{$p['username']} (Car 2 passenger) has no home coordinates — pickup waypoint skipped.";
+                    }
+                } else {
+                    // Travels with Car 1 (default).
+                    if ($hasCoords) {
+                        $car1Stops[] = [$lat, $lng];
+                    } else {
+                        $warnings[] = "{$p['username']} (Car 1 passenger) has no home coordinates — pickup waypoint skipped.";
+                    }
+                }
             }
         }
 

--- a/cli/lib/TravelCalculator.php
+++ b/cli/lib/TravelCalculator.php
@@ -84,10 +84,11 @@ class TravelCalculator
         array $ferry = ['requires_ferry' => false, 'cost_eur' => 0.0]
     ): array {
         $warnings   = [];
-        $car1Driver = null;   // [lat, lng]
-        $car1Stops  = [];     // ordered waypoints added between driver home and venue
-        $car2Driver = null;   // [lat, lng]
-        $car2Stops  = [];     // ordered waypoints added between driver home and venue
+        // Each entry: ['lat' => float, 'lng' => float, 'label' => string]
+        $car1Driver = null;
+        $car1Stops  = [];
+        $car2Driver = null;
+        $car2Stops  = [];
 
         foreach ($personnel as $p) {
             $effectiveMode     = $p['transport_override'] ?? $p['transport_mode'];
@@ -101,7 +102,7 @@ class TravelCalculator
                     if (!$hasCoords) {
                         $warnings[] = "Car 1 driver ({$p['username']}) has no home coordinates — Car 1 route unavailable.";
                     } else {
-                        $car1Driver = [$lat, $lng];
+                        $car1Driver = ['lat' => $lat, 'lng' => $lng, 'label' => "{$p['username']} (keyboards, Car 1 driver)"];
                     }
                     break;
 
@@ -109,7 +110,7 @@ class TravelCalculator
                 case 'vocals':
                     // Always Car 1 passenger (Joni, Alina — Turku-based)
                     if ($hasCoords) {
-                        $car1Stops[] = [$lat, $lng];
+                        $car1Stops[] = ['lat' => $lat, 'lng' => $lng, 'label' => "{$p['username']} ({$p['role']})"];
                     } else {
                         $warnings[] = "{$p['username']} ({$p['role']}) has no home coordinates — pickup waypoint skipped.";
                     }
@@ -122,7 +123,7 @@ class TravelCalculator
                         break;
                     }
                     if ($hasCoords) {
-                        $car2Stops[] = [$lat, $lng];
+                        $car2Stops[] = ['lat' => $lat, 'lng' => $lng, 'label' => "{$p['username']} (guitar)"];
                     } else {
                         $warnings[] = "{$p['username']} (guitar) has no home coordinates — Car 2 pickup skipped.";
                     }
@@ -133,7 +134,7 @@ class TravelCalculator
                     if (!$hasCoords) {
                         $warnings[] = "Car 2 driver ({$p['username']}) has no home coordinates — Car 2 route unavailable.";
                     } else {
-                        $car2Driver = [$lat, $lng];
+                        $car2Driver = ['lat' => $lat, 'lng' => $lng, 'label' => "{$p['username']} (bass, Car 2 driver)"];
                     }
                     break;
 
@@ -144,14 +145,14 @@ class TravelCalculator
                     } elseif ($effectiveMode === 'passenger') {
                         // Car 1 passenger (Toni — Turku-based passenger)
                         if ($hasCoords) {
-                            $car1Stops[] = [$lat, $lng];
+                            $car1Stops[] = ['lat' => $lat, 'lng' => $lng, 'label' => "{$p['username']} (sound engineering)"];
                         } else {
                             $warnings[] = "{$p['username']} (sound engineering, Car 1) has no home coordinates — pickup waypoint skipped.";
                         }
                     } else {
                         // car_owner without override = Car 2 pickup (Valtteri typical case)
                         if ($hasCoords) {
-                            $car2Stops[] = [$lat, $lng];
+                            $car2Stops[] = ['lat' => $lat, 'lng' => $lng, 'label' => "{$p['username']} (sound engineering, Car 2 pickup)"];
                         } else {
                             $warnings[] = "{$p['username']} (sound engineering, Car 2 pickup) has no home coordinates — waypoint skipped.";
                         }
@@ -160,8 +161,10 @@ class TravelCalculator
             }
         }
 
-        $car1Km = self::computeCarRoute($car1Driver, $car1Stops, $venueLat, $venueLng, true);
-        $car2Km = self::computeCarRoute($car2Driver, $car2Stops, $venueLat, $venueLng, false);
+        $car1Result = self::computeCarRouteDetail($car1Driver, $car1Stops, $venueLat, $venueLng, true);
+        $car2Result = self::computeCarRouteDetail($car2Driver, $car2Stops, $venueLat, $venueLng, false);
+        $car1Km = $car1Result['km'];
+        $car2Km = $car2Result['km'];
 
         if ($car1Driver !== null && $car1Km === null) {
             $warnings[] = 'Car 1 OSRM routing failed — check network and waypoint coordinates.';
@@ -180,48 +183,67 @@ class TravelCalculator
             'car2_km'         => $car2Km,
             'ferry_costs_eur' => $ferryCosts,
             'warnings'        => $warnings,
+            'car1_route'      => $car1Result['route'],
+            'car2_route'      => $car2Result['route'],
         ];
     }
 
     /**
-     * Build and query one car's route.
+     * Build and query one car's route, returning km and labelled route detail.
      * Route: driver home → [trailer if Car 1] → stops[] → venue → back to driver home (× 2 approx).
      *
-     * @param array|null $driver  [lat, lng] or null
-     * @param array      $stops   additional pickup waypoints [[lat,lng], ...]
+     * @param array|null $driver  ['lat', 'lng', 'label'] or null
+     * @param array      $stops   additional pickup waypoints [['lat','lng','label'], ...]
      * @param float      $venueLat
      * @param float      $venueLng
      * @param bool       $isCar1  if true, inserts trailer waypoint after driver home
-     * @return float|null  round-trip km or null if no driver / OSRM failure
+     * @return array{km: float|null, route: array|null}
      */
-    private static function computeCarRoute(
+    private static function computeCarRouteDetail(
         ?array $driver,
         array  $stops,
         float  $venueLat,
         float  $venueLng,
         bool   $isCar1
-    ): ?float {
+    ): array {
         if ($driver === null) {
-            return null;
+            return ['km' => null, 'route' => null];
         }
 
-        $waypoints = [$driver];
+        // Labelled waypoints for display
+        $labelledWaypoints = [
+            ['label' => $driver['label'], 'lat' => $driver['lat'], 'lng' => $driver['lng']],
+        ];
 
         if ($isCar1) {
-            $waypoints[] = [self::TRAILER_LAT, self::TRAILER_LNG];
+            $labelledWaypoints[] = ['label' => 'Trailer (Opettajankatu 9)', 'lat' => self::TRAILER_LAT, 'lng' => self::TRAILER_LNG];
         }
 
         foreach ($stops as $stop) {
-            $waypoints[] = $stop;
+            $labelledWaypoints[] = ['label' => $stop['label'], 'lat' => $stop['lat'], 'lng' => $stop['lng']];
         }
 
-        $waypoints[] = [$venueLat, $venueLng];
+        $labelledWaypoints[] = ['label' => 'Venue', 'lat' => $venueLat, 'lng' => $venueLng];
 
-        $oneWayKm = RoutingHelper::waypointRouteKm($waypoints);
-        if ($oneWayKm === null) {
-            return null;
+        // Flat [lat, lng] pairs for OSRM
+        $coords = array_map(fn($w) => [$w['lat'], $w['lng']], $labelledWaypoints);
+
+        $detail = RoutingHelper::waypointRouteDetail($coords);
+        if ($detail === null) {
+            return ['km' => null, 'route' => null];
         }
-        return round($oneWayKm * 2, 1); // round trip
+
+        $oneWayKm    = $detail['total_km'];
+        $roundTripKm = round($oneWayKm * 2, 1);
+
+        return [
+            'km'    => $roundTripKm,
+            'route' => [
+                'waypoints'   => $labelledWaypoints,
+                'one_way_km'  => $oneWayKm,
+                'legs_km'     => $detail['legs_km'],
+            ],
+        ];
     }
 
     /**

--- a/cli/lib/TravelCalculator.php
+++ b/cli/lib/TravelCalculator.php
@@ -169,6 +169,15 @@ class TravelCalculator
             }
         }
 
+        // Car 2 fallback: if no Car 2 driver, roll Car 2 passengers into Car 1.
+        // Must happen before computeCarRouteDetail so they appear in the route.
+        if ($car2Driver === null && !empty($car2Stops)) {
+            $stopNames = implode(', ', array_column($car2Stops, 'label'));
+            $warnings[] = "No Car 2 driver in lineup — Car 2 passenger(s) added to Car 1 route: $stopNames.";
+            $car1Stops = array_merge($car1Stops, $car2Stops);
+            $car2Stops = [];
+        }
+
         $car1Result = self::computeCarRouteDetail($car1Driver, $car1Stops, $venueLat, $venueLng, true);
         $car2Result = self::computeCarRouteDetail($car2Driver, $car2Stops, $venueLat, $venueLng, false);
         $car1Km = $car1Result['km'];
@@ -179,15 +188,6 @@ class TravelCalculator
         }
         if ($car2Driver !== null && $car2Km === null) {
             $warnings[] = 'Car 2 OSRM routing failed — check network and waypoint coordinates.';
-        }
-        if ($car2Driver === null && !empty($car2Stops)) {
-            // No Car 2 driver in lineup: fall back these passengers to Car 1.
-            // Car 1 (Caddy) has capacity; this handles any lineup that omits Mortti/Maxwell.
-            // Owner can override per-person with transport_override='local' if they drive themselves.
-            $stopNames = implode(', ', array_column($car2Stops, 'label'));
-            $warnings[] = "No Car 2 driver in lineup — Car 2 passenger(s) added to Car 1 route: $stopNames.";
-            $car1Stops = array_merge($car1Stops, $car2Stops);
-            $car2Stops = [];
         }
 
         $ferryCosts = 0.0;

--- a/db/migrations/011_route_json.sql
+++ b/db/migrations/011_route_json.sql
@@ -1,0 +1,9 @@
+-- Migration 011: add car route JSON columns to gigs
+-- Stores the calculated route detail (waypoints + per-leg km) so it is
+-- visible in the gig detail view and auditable after recalculation.
+
+ALTER TABLE gigs
+  ADD COLUMN car1_route_json TEXT DEFAULT NULL
+    COMMENT 'JSON: {"waypoints":[{"label":"...","lat":...,"lng":...}],"one_way_km":...,"legs_km":[...]}',
+  ADD COLUMN car2_route_json TEXT DEFAULT NULL
+    COMMENT 'JSON: same shape as car1_route_json';

--- a/db/migrations/012_users_default_car.sql
+++ b/db/migrations/012_users_default_car.sql
@@ -1,0 +1,17 @@
+-- Migration 012: add default_car to users
+-- Encodes which band car a person defaults to.
+-- Used by TravelCalculator to determine driver vs passenger assignment
+-- independently of the gig role they happen to be assigned.
+--
+-- Values: 1 = Car 1 (Caddy, Tuomas driving), 2 = Car 2 (own car, Mortti/Maxwell driving)
+-- Default is 1 because most musicians ride in Car 1.
+
+ALTER TABLE users
+  ADD COLUMN default_car TINYINT(1) UNSIGNED NOT NULL DEFAULT 1
+    COMMENT '1=Car 1 (Caddy), 2=Car 2. Used by TravelCalculator; independent of gig role.';
+
+-- Seed correct values for known musicians.
+-- Car 2: Mortti (driver) and Lauri (Helsinki pickup, rides with Car 2 driver).
+UPDATE users SET default_car = 2
+WHERE username IN ('mortti.markkanen', 'lauri.lehtinen')
+  AND deleted_at IS NULL;

--- a/db/migrations/013_valtteri_transport_fix.sql
+++ b/db/migrations/013_valtteri_transport_fix.sql
@@ -1,0 +1,16 @@
+-- Migration 013: fix valtteri.alanen transport_mode and default_car
+--
+-- Under the OLD role-based TravelCalculator, transport_mode='car_owner' for
+-- sound engineering meant "Car 2 pickup by default; transport_override='car_owner'
+-- on the gig row when he drives himself". The new person-based model uses
+-- transport_mode='car_owner' exclusively for designated band car drivers
+-- (Tuomas = Car 1, Mortti/Maxwell = Car 2). Everyone else who rides in a
+-- band car is 'passenger'.
+--
+-- Valtteri rides in Car 2 by default. When he drives himself to a gig the
+-- owner sets gig_personnel.transport_override = 'local'.
+
+UPDATE users
+SET    transport_mode = 'passenger',
+       default_car    = 2
+WHERE  username = 'valtteri.alanen';

--- a/db/schema/core.sql
+++ b/db/schema/core.sql
@@ -148,6 +148,9 @@ CREATE TABLE IF NOT EXISTS gigs (
     car1_distance_km        DECIMAL(7,1)             DEFAULT NULL,
     car2_distance_km        DECIMAL(7,1)             DEFAULT 0.0,
     other_travel_costs_cents INT                     DEFAULT 0,
+    -- Route detail JSON: {"waypoints":[{"label","lat","lng"}],"one_way_km","legs_km":[]}
+    car1_route_json         TEXT                     DEFAULT NULL,
+    car2_route_json         TEXT                     DEFAULT NULL,
     -- Granular pricing inputs (see PriceCalculator; persisted so the edit form pre-populates)
     pricing_tier1            TINYINT(1)              NOT NULL DEFAULT 0, -- on-season Saturday flag
     pricing_tier2            TINYINT(1)              NOT NULL DEFAULT 0, -- high-demand date flag

--- a/db/schema/core.sql
+++ b/db/schema/core.sql
@@ -284,9 +284,14 @@ CREATE TABLE IF NOT EXISTS users (
     home_address   VARCHAR(255)           DEFAULT NULL,
     home_lat       DECIMAL(9,6)           DEFAULT NULL,
     home_lng       DECIMAL(9,6)           DEFAULT NULL,
-    -- transport_mode: car_owner = has own vehicle; passenger = always needs a lift
+    -- transport_mode: car_owner = drives a billed band car; passenger = needs a lift; local = own car, unbilled
     transport_mode ENUM('car_owner','passenger','public_transport')
                                  NOT NULL DEFAULT 'passenger',
+    -- default_car: which band car this person belongs to by default (1=Caddy/Car1, 2=Car2).
+    -- car_owner with default_car=1 → Car 1 driver (Tuomas); default_car=2 → Car 2 driver (Mortti/Maxwell).
+    -- passenger with default_car=1 → Car 1 stop; default_car=2 → Car 2 pickup (e.g. Lauri, Helsinki).
+    -- Gig-level overrides go on gig_personnel.transport_override.
+    default_car    TINYINT(1) UNSIGNED NOT NULL DEFAULT 1,
     password_hash  VARCHAR(255)  NOT NULL,
     role           ENUM(
                        'developer',

--- a/db/schema/core.sql
+++ b/db/schema/core.sql
@@ -148,7 +148,7 @@ CREATE TABLE IF NOT EXISTS gigs (
     car1_distance_km        DECIMAL(7,1)             DEFAULT NULL,
     car2_distance_km        DECIMAL(7,1)             DEFAULT 0.0,
     other_travel_costs_cents INT                     DEFAULT 0,
-    -- Route detail JSON: {"waypoints":[{"label","lat","lng"}],"one_way_km","legs_km":[]}
+    -- Route detail JSON shape: {"waypoints":[{"label":"tuomas (Car 1 driver)","lat":60.451,"lng":22.267}],"one_way_km":42.3,"legs_km":[3.8,5.1,33.4]}
     car1_route_json         TEXT                     DEFAULT NULL,
     car2_route_json         TEXT                     DEFAULT NULL,
     -- Granular pricing inputs (see PriceCalculator; persisted so the edit form pre-populates)
@@ -190,9 +190,9 @@ CREATE TABLE IF NOT EXISTS gig_personnel (
                        ) NOT NULL DEFAULT 'other',
     fee_cents          INT                     DEFAULT NULL,
     -- transport_override: NULL = use users.transport_mode default
-    --   passenger  = rides Car 2 pickup (Valtteri typical case when car_owner)
-    --   local      = skip out-of-town pickup (Lauri already in Turku)
-    --   car_owner  = drives own car this gig (warn; not billed in Car 1/2)
+    --   passenger  = overrides to band car passenger for this gig
+    --   local      = drives own car to venue, not billed (e.g. Lauri already in Turku)
+    --   car_owner  = drives own non-band car this gig, not billed (treated same as local by TravelCalculator)
     transport_override ENUM('car_owner','passenger','local') DEFAULT NULL,
     confirmed_at       DATETIME                DEFAULT NULL,
     created_at         DATETIME       NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -287,7 +287,9 @@ CREATE TABLE IF NOT EXISTS users (
     home_address   VARCHAR(255)           DEFAULT NULL,
     home_lat       DECIMAL(9,6)           DEFAULT NULL,
     home_lng       DECIMAL(9,6)           DEFAULT NULL,
-    -- transport_mode: car_owner = drives a billed band car; passenger = needs a lift; local = own car, unbilled
+    -- transport_mode: car_owner = designated driver of a billed band car (Tuomas=Car1, Mortti/Maxwell=Car2);
+    --   passenger = needs a lift in a band car; public_transport = travels independently (train/bus), no pickup.
+    --   Note: 'local' (drives own car to venue, unbilled) is only a gig_personnel.transport_override value.
     transport_mode ENUM('car_owner','passenger','public_transport')
                                  NOT NULL DEFAULT 'passenger',
     -- default_car: which band car this person belongs to by default (1=Caddy/Car1, 2=Car2).

--- a/db/seeds/musician_addresses.sql
+++ b/db/seeds/musician_addresses.sql
@@ -51,10 +51,10 @@ UPDATE users SET
     transport_mode = 'car_owner'
 WHERE username = 'maxwell.mbare';
 
--- Car 2 pickup (sound engineering — Valtteri; has own car but typically picked up)
--- transport_mode = car_owner so TravelCalculator defaults to Car 2 pickup;
--- owner sets gig_personnel.transport_override = 'car_owner' when Valtteri drives himself.
+-- Car 2 passenger (sound engineering — Valtteri; rides Car 2 by default)
+-- When he drives himself to a gig, set gig_personnel.transport_override = 'local'.
 UPDATE users SET
     home_address   = 'Kaarina, Varsinais-Suomi',
-    transport_mode = 'car_owner'
+    transport_mode = 'passenger',
+    default_car    = 2
 WHERE username = 'valtteri.alanen';

--- a/src/modules/agent/lib/GigCreator.php
+++ b/src/modules/agent/lib/GigCreator.php
@@ -37,10 +37,12 @@ class GigCreator
      * @param  PDO    $pdo
      * @param  array  $fields  See class docblock for expected keys.
      * @param  string $channel ENUM value from gigs.channel (e.g. 'mail', 'saturday_band')
+     * @param  string $status  ENUM value from gigs.status (default 'inquiry')
      * @return int             ID of the newly created gig row.
      * @throws RuntimeException on database failure.
+     * @throws \InvalidArgumentException if $status is not a valid enum value.
      */
-    public static function create(PDO $pdo, array $fields, string $channel): int
+    public static function create(PDO $pdo, array $fields, string $channel, string $status = 'inquiry'): int
     {
         $customerName    = $fields['customer_name']      ?? 'Unknown';
         $customerType    = $fields['customer_type']      ?? 'other';
@@ -64,6 +66,9 @@ class GigCreator
 
         if (!in_array($customerType, ['wedding', 'company', 'other'], true)) {
             $customerType = 'other';
+        }
+        if (!in_array($status, ['inquiry', 'quoted', 'confirmed', 'delivered', 'cancelled', 'declined'], true)) {
+            throw new \InvalidArgumentException("Invalid gig status: $status");
         }
         if ($customerName === '') $customerName = 'Unknown';
         if ($venueName    === '') $venueName    = 'Unknown';
@@ -134,10 +139,10 @@ class GigCreator
                     qty_ennakkoroudaus, qty_song_requests_extra, qty_extra_performances,
                     qty_background_music_h, qty_live_album, discount_cents,
                     notes)
-                 VALUES (?, ?, ?, ?, 'inquiry', ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, 0, 0, 0, 0, ?)"
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, 0, 0, 0, 0, ?)"
             )->execute([
                 $customerId, $contactId, $venueId, $gigDate,
-                $channel, $customerType, $orderDesc,
+                $status, $channel, $customerType, $orderDesc,
                 $basePriceCents, $basePriceCents,
                 $car1Km, $car2Km ?? 0, $otherTravelCents,
                 $notes,

--- a/src/modules/agent/lib/GigCreator.php
+++ b/src/modules/agent/lib/GigCreator.php
@@ -61,6 +61,8 @@ class GigCreator
         $car2Km          = $fields['car2_km']            ?? null;
         $otherTravelCents = (int)($fields['other_travel_cents'] ?? 0);
         $basePriceCents  = (int)($fields['base_price_cents']    ?? 0);
+        $car1RouteJson   = isset($fields['car1_route']) ? json_encode($fields['car1_route']) : null;
+        $car2RouteJson   = isset($fields['car2_route']) ? json_encode($fields['car2_route']) : null;
 
         if (!in_array($customerType, ['wedding', 'company', 'other'], true)) {
             $customerType = 'other';
@@ -130,16 +132,18 @@ class GigCreator
                    (customer_id, contact_id, venue_id, gig_date, status, channel, customer_type,
                     order_description, base_price_cents, quoted_price_cents,
                     car1_distance_km, car2_distance_km, other_travel_costs_cents,
+                    car1_route_json, car2_route_json,
                     pricing_tier1, pricing_tier2,
                     qty_ennakkoroudaus, qty_song_requests_extra, qty_extra_performances,
                     qty_background_music_h, qty_live_album, discount_cents,
                     notes)
-                 VALUES (?, ?, ?, ?, 'inquiry', ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, 0, 0, 0, 0, ?)"
+                 VALUES (?, ?, ?, ?, 'inquiry', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, 0, 0, 0, 0, ?)"
             )->execute([
                 $customerId, $contactId, $venueId, $gigDate,
                 $channel, $customerType, $orderDesc,
                 $basePriceCents, $basePriceCents,
                 $car1Km, $car2Km ?? 0, $otherTravelCents,
+                $car1RouteJson, $car2RouteJson,
                 $notes,
             ]);
             $gigId = (int)$pdo->lastInsertId();

--- a/src/modules/agent/process_inquiry.php
+++ b/src/modules/agent/process_inquiry.php
@@ -120,6 +120,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $car1Km           = $travel['car1_km'];
         $car2Km           = $travel['car2_km'] ?? 0;
         $otherTravelCents = (int)round($travel['ferry_costs_eur'] * 100);
+        $car1Route        = $travel['car1_route'] ?? null;
+        $car2Route        = $travel['car2_route'] ?? null;
     }
 
     // --- Price calculation with extracted inputs (baseline) -------------------
@@ -169,6 +171,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             'car2_km'            => $car2Km,
             'other_travel_cents' => $otherTravelCents,
             'base_price_cents'   => $basePriceCents,
+            'car1_route'         => $car1Route ?? null,
+            'car2_route'         => $car2Route ?? null,
         ], 'mail');
     } catch (RuntimeException $e) {
         error_log('Agent inquiry save failed: ' . $e->getMessage());

--- a/src/modules/agent/process_inquiry.php
+++ b/src/modules/agent/process_inquiry.php
@@ -86,30 +86,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             'tuomas.lundberg', 'toni.puttonen', 'joni.virtanen',
             'alina.kangas', 'lauri.lehtinen', 'mortti.markkanen',
         ];
-        // Role assignments for synthetic default lineup
-        $defaultRoles = [
-            'tuomas.lundberg' => 'keyboards',
-            'toni.puttonen'   => 'sound_engineering',
-            'joni.virtanen'   => 'drums',
-            'alina.kangas'    => 'vocals',
-            'lauri.lehtinen'  => 'guitar',
-            'mortti.markkanen'=> 'bass',
-        ];
         $placeholders = implode(',', array_fill(0, count($defaultUsernames), '?'));
         $userStmt = $pdo->prepare(
-            "SELECT username, home_lat, home_lng, transport_mode
+            "SELECT username, home_lat, home_lng, transport_mode, default_car
              FROM   users WHERE username IN ($placeholders) AND deleted_at IS NULL"
         );
         $userStmt->execute($defaultUsernames);
         $defaultUsers = $userStmt->fetchAll(PDO::FETCH_ASSOC);
 
         $synthPersonnel = array_map(fn($u) => [
-            'role'               => $defaultRoles[$u['username']] ?? 'other',
+            'role'               => 'other', // role is irrelevant; transport_mode + default_car drive assignment
             'transport_override' => null,
             'username'           => $u['username'],
             'home_lat'           => $u['home_lat'],
             'home_lng'           => $u['home_lng'],
             'transport_mode'     => $u['transport_mode'],
+            'default_car'        => $u['default_car'],
         ], $defaultUsers);
 
         $travel = TravelCalculator::calculateFromPersonnel(

--- a/src/modules/gigs/detail.php
+++ b/src/modules/gigs/detail.php
@@ -231,6 +231,37 @@ render_layout($gig['customer_name'], function () use ($gig, $transitions, $perso
             </dd>
           </dl>
 
+          <?php
+          $car1Route = isset($gig['car1_route_json']) ? json_decode($gig['car1_route_json'], true) : null;
+          $car2Route = isset($gig['car2_route_json']) ? json_decode($gig['car2_route_json'], true) : null;
+          if ($car1Route || $car2Route):
+          ?>
+          <div class="mt-2">
+            <a class="small text-muted" data-bs-toggle="collapse" href="#routeDetail" role="button">
+              Route detail ▾
+            </a>
+            <div class="collapse mt-2" id="routeDetail">
+              <?php foreach ([['Car 1', $car1Route], ['Car 2', $car2Route]] as [$label, $route]): ?>
+              <?php if ($route): ?>
+              <p class="small fw-semibold mb-1"><?= $label ?> — one-way <?= $route['one_way_km'] ?> km (round trip <?= round($route['one_way_km'] * 2, 1) ?> km)</p>
+              <table class="table table-sm table-bordered small mb-3">
+                <thead class="table-light"><tr><th>#</th><th>Waypoint</th><th class="text-end">Leg km</th></tr></thead>
+                <tbody>
+                <?php foreach ($route['waypoints'] as $i => $wp): ?>
+                <tr>
+                  <td><?= $i + 1 ?></td>
+                  <td><?= htmlspecialchars($wp['label']) ?></td>
+                  <td class="text-end"><?= isset($route['legs_km'][$i]) ? $route['legs_km'][$i] . ' km' : '—' ?></td>
+                </tr>
+                <?php endforeach; ?>
+                </tbody>
+              </table>
+              <?php endif; ?>
+              <?php endforeach; ?>
+            </div>
+          </div>
+          <?php endif; ?>
+
           <hr class="my-2">
 
           <dl class="row mb-0">

--- a/src/modules/gigs/travel_calculate.php
+++ b/src/modules/gigs/travel_calculate.php
@@ -47,12 +47,16 @@ $pdo->prepare(
     "UPDATE gigs SET
         car1_distance_km          = ?,
         car2_distance_km          = ?,
-        other_travel_costs_cents  = ?
+        other_travel_costs_cents  = ?,
+        car1_route_json           = ?,
+        car2_route_json           = ?
      WHERE id = ?"
 )->execute([
     $result['car1_km'],
     $result['car2_km'] ?? 0,
     (int)round($result['ferry_costs_eur'] * 100),
+    isset($result['car1_route']) ? json_encode($result['car1_route']) : null,
+    isset($result['car2_route']) ? json_encode($result['car2_route']) : null,
     $gigId,
 ]);
 

--- a/src/modules/gigs/travel_calculate.php
+++ b/src/modules/gigs/travel_calculate.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../../../cli/lib/TravelCalculator.php';
+require_once __DIR__ . '/../agent/lib/GeocodingHelper.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     http_response_code(405);
@@ -14,9 +15,10 @@ if (!$gigId) {
     exit;
 }
 
-// Fetch gig + venue coordinates
+// Fetch gig + venue coordinates and address fields for on-demand geocoding.
 $stmt = $pdo->prepare(
-    "SELECT g.id, v.lat, v.lng, v.distance_from_turku_km
+    "SELECT g.id, v.id AS venue_id, v.lat, v.lng, v.distance_from_turku_km,
+            v.address_line, v.city, v.name AS venue_name
      FROM   gigs g
      LEFT JOIN venues v ON v.id = g.venue_id
      WHERE  g.id = ? AND g.deleted_at IS NULL"
@@ -29,8 +31,30 @@ if (!$row) {
     exit;
 }
 
+// If venue has no coordinates, attempt on-demand geocoding from address/city/name.
+// Legacy imported gigs have address data but were never run through the inquiry pipeline.
+if (($row['lat'] === null || $row['lng'] === null) && $row['venue_id'] !== null) {
+    $geocodeQuery = trim(($row['address_line'] ?? '') . ' ' . ($row['city'] ?? ''));
+    if ($geocodeQuery === '') {
+        $geocodeQuery = trim($row['venue_name'] ?? '');
+    }
+
+    $geo = $geocodeQuery !== '' ? GeocodingHelper::geocodeVenue($geocodeQuery, '') : null;
+
+    if ($geo !== null) {
+        $row['lat'] = $geo['lat'];
+        $row['lng'] = $geo['lng'];
+        // Persist coords; update distance_from_turku_km only if not already set.
+        $pdo->prepare(
+            "UPDATE venues SET lat = ?, lng = ?,
+                distance_from_turku_km = COALESCE(distance_from_turku_km, ?)
+             WHERE id = ?"
+        )->execute([$geo['lat'], $geo['lng'], $geo['distance_km'], $row['venue_id']]);
+    }
+}
+
 if ($row['lat'] === null || $row['lng'] === null) {
-    // Venue not geocoded yet — cannot run TravelCalculator
+    // Venue has no coordinates and no address to geocode from.
     header('Location: /gigs/' . $gigId . '?error=travel_no_venue_coords');
     exit;
 }

--- a/src/modules/webhook/webflow.php
+++ b/src/modules/webhook/webflow.php
@@ -281,6 +281,8 @@ function runPipelineAndCreate(PDO $pdo, array $fields, string $channel): int
         $car1Km           = $travel['car1_km'];
         $car2Km           = $travel['car2_km'] ?? 0;
         $otherTravelCents = (int)round($travel['ferry_costs_eur'] * 100);
+        $car1Route        = $travel['car1_route'] ?? null;
+        $car2Route        = $travel['car2_route'] ?? null;
     }
 
     // Price calculation.
@@ -310,5 +312,7 @@ function runPipelineAndCreate(PDO $pdo, array $fields, string $channel): int
         'car2_km'            => $car2Km,
         'other_travel_cents' => $otherTravelCents,
         'base_price_cents'   => $basePriceCents,
+        'car1_route'         => $car1Route ?? null,
+        'car2_route'         => $car2Route ?? null,
     ]), $channel);
 }

--- a/src/modules/webhook/webflow.php
+++ b/src/modules/webhook/webflow.php
@@ -163,6 +163,11 @@ function handleEmailForm(PDO $pdo, array $data): int
         $fields['contact_email'] = $email;
     }
 
+    // Fall back to raw message if AI extraction left order_description empty.
+    if (empty($fields['order_description']) && $message !== '') {
+        $fields['order_description'] = mb_substr($message, 0, 255);
+    }
+
     return runPipelineAndCreate($pdo, $fields, 'saturday_band');
 }
 
@@ -199,6 +204,18 @@ function handleTilauslomake(PDO $pdo, array $data): int
     }
     $notes = $notesParts ? implode("\n", $notesParts) : null;
 
+    // Build a concise order_description from structured fields.
+    $descParts = ['Tilauslomake'];
+    if ($gigDate !== null) {
+        $descParts[] = $gigDate;
+    } elseif ($dateRaw !== '') {
+        $descParts[] = $dateRaw;
+    }
+    if ($customerName !== '') {
+        $descParts[] = $customerName;
+    }
+    $orderDesc = mb_substr(implode(' – ', $descParts), 0, 255);
+
     $fields = [
         'customer_name'      => $customerName,
         'customer_type'      => $customerType,
@@ -210,17 +227,17 @@ function handleTilauslomake(PDO $pdo, array $data): int
         'contact_last_name'  => $lastName,
         'contact_email'      => $email ?: null,
         'contact_phone'      => $phone ?: null,
-        'order_description'  => null,
+        'order_description'  => $orderDesc,
         'notes'              => $notes,
     ];
 
-    return runPipelineAndCreate($pdo, $fields, 'saturday_band');
+    return runPipelineAndCreate($pdo, $fields, 'saturday_band', 'confirmed');
 }
 
 /**
  * Shared geocoding + travel + price calculation + GigCreator::create().
  */
-function runPipelineAndCreate(PDO $pdo, array $fields, string $channel): int
+function runPipelineAndCreate(PDO $pdo, array $fields, string $channel, string $status = 'inquiry'): int
 {
     $venueName    = trim($fields['venue_name']    ?? '');
     $venueAddress = trim($fields['venue_address'] ?? '') ?: null;
@@ -310,5 +327,5 @@ function runPipelineAndCreate(PDO $pdo, array $fields, string $channel): int
         'car2_km'            => $car2Km,
         'other_travel_cents' => $otherTravelCents,
         'base_price_cents'   => $basePriceCents,
-    ]), $channel);
+    ]), $channel, $status);
 }

--- a/src/modules/webhook/webflow.php
+++ b/src/modules/webhook/webflow.php
@@ -252,29 +252,22 @@ function runPipelineAndCreate(PDO $pdo, array $fields, string $channel): int
             'tuomas.lundberg', 'toni.puttonen', 'joni.virtanen',
             'alina.kangas', 'lauri.lehtinen', 'mortti.markkanen',
         ];
-        $defaultRoles = [
-            'tuomas.lundberg'  => 'keyboards',
-            'toni.puttonen'    => 'sound_engineering',
-            'joni.virtanen'    => 'drums',
-            'alina.kangas'     => 'vocals',
-            'lauri.lehtinen'   => 'guitar',
-            'mortti.markkanen' => 'bass',
-        ];
         $placeholders = implode(',', array_fill(0, count($defaultUsernames), '?'));
         $userStmt = $pdo->prepare(
-            "SELECT username, home_lat, home_lng, transport_mode
+            "SELECT username, home_lat, home_lng, transport_mode, default_car
              FROM   users WHERE username IN ($placeholders) AND deleted_at IS NULL"
         );
         $userStmt->execute($defaultUsernames);
         $defaultUsers = $userStmt->fetchAll(PDO::FETCH_ASSOC);
 
         $synthPersonnel = array_map(fn($u) => [
-            'role'               => $defaultRoles[$u['username']] ?? 'other',
+            'role'               => 'other', // role is irrelevant; transport_mode + default_car drive assignment
             'transport_override' => null,
             'username'           => $u['username'],
             'home_lat'           => $u['home_lat'],
             'home_lng'           => $u['home_lng'],
             'transport_mode'     => $u['transport_mode'],
+            'default_car'        => $u['default_car'],
         ], $defaultUsers);
 
         $travel = TravelCalculator::calculateFromPersonnel($synthPersonnel, $venueLat, $venueLng);


### PR DESCRIPTION
Merges PRs #27–#30 + #28 conflict resolution:
- Migration 011: car1/car2 route JSON columns on gigs
- Migration 012: users.default_car column
- TravelCalculator: person-based car assignment (transport_mode + default_car)
- Route detail: labelled waypoints + per-leg km stored and displayed
- Tilauslomake → status=confirmed; order_description populated from payload
- On-demand geocoding for legacy venues on Recalculate travel