### PR TITLE
fix: correct valtteri transport_mode + duplicate car driver warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- **Valtteri's transport_mode corrected to passenger/Car2** — was set to `car_owner`
+  under old role-based semantics; under the new person-based model this incorrectly made
+  him Car 1 driver and silently dropped the real Car 1 driver from the route. Now
+  `passenger` + `default_car=2`; gig-level override remains `transport_override='local'`
+  when he drives himself. Migration 013 updates the live row; musician_addresses.sql updated
+  to match.
+- **TravelCalculator: warn on duplicate car driver assignment** — previously the last
+  `car_owner` processed for a given car slot silently overwrote the first, causing the
+  real driver to vanish from the route with no indication. Now first-wins and a warning
+  is emitted for the duplicate.
 - **TravelCalculator: car assignment now based on person, not gig role** — the previous
   implementation used the gig role (keyboards→Car1, bass→Car2, etc.) as a proxy for which car
   someone travels in, which broke whenever roles were assigned to non-default musicians.

--- a/cli/lib/TravelCalculator.php
+++ b/cli/lib/TravelCalculator.php
@@ -117,14 +117,18 @@ class TravelCalculator
                 // This person drives a band car.
                 if ($defaultCar === 2) {
                     // Car 2 driver (Mortti, Maxwell).
-                    if (!$hasCoords) {
+                    if ($car2Driver !== null) {
+                        $warnings[] = "Duplicate Car 2 driver: {$p['username']} ignored — {$car2Driver['label']} already assigned. Check users.default_car and transport_mode.";
+                    } elseif (!$hasCoords) {
                         $warnings[] = "Car 2 driver ({$p['username']}) has no home coordinates — Car 2 route unavailable.";
                     } else {
                         $car2Driver = ['lat' => $lat, 'lng' => $lng, 'label' => "{$p['username']} (Car 2 driver)"];
                     }
                 } else {
                     // Car 1 driver (Tuomas).
-                    if (!$hasCoords) {
+                    if ($car1Driver !== null) {
+                        $warnings[] = "Duplicate Car 1 driver: {$p['username']} ignored — {$car1Driver['label']} already assigned. Check users.default_car and transport_mode.";
+                    } elseif (!$hasCoords) {
                         $warnings[] = "Car 1 driver ({$p['username']}) has no home coordinates — Car 1 route unavailable.";
                     } else {
                         $car1Driver = ['lat' => $lat, 'lng' => $lng, 'label' => "{$p['username']} (Car 1 driver)"];

--- a/db/migrations/013_valtteri_transport_fix.sql
+++ b/db/migrations/013_valtteri_transport_fix.sql
@@ -1,0 +1,16 @@
+-- Migration 013: fix valtteri.alanen transport_mode and default_car
+--
+-- Under the OLD role-based TravelCalculator, transport_mode='car_owner' for
+-- sound engineering meant "Car 2 pickup by default; transport_override='car_owner'
+-- on the gig row when he drives himself". The new person-based model uses
+-- transport_mode='car_owner' exclusively for designated band car drivers
+-- (Tuomas = Car 1, Mortti/Maxwell = Car 2). Everyone else who rides in a
+-- band car is 'passenger'.
+--
+-- Valtteri rides in Car 2 by default. When he drives himself to a gig the
+-- owner sets gig_personnel.transport_override = 'local'.
+
+UPDATE users
+SET    transport_mode = 'passenger',
+       default_car    = 2
+WHERE  username = 'valtteri.alanen';

--- a/db/seeds/musician_addresses.sql
+++ b/db/seeds/musician_addresses.sql
@@ -51,10 +51,10 @@ UPDATE users SET
     transport_mode = 'car_owner'
 WHERE username = 'maxwell.mbare';
 
--- Car 2 pickup (sound engineering — Valtteri; has own car but typically picked up)
--- transport_mode = car_owner so TravelCalculator defaults to Car 2 pickup;
--- owner sets gig_personnel.transport_override = 'car_owner' when Valtteri drives himself.
+-- Car 2 passenger (sound engineering — Valtteri; rides Car 2 by default)
+-- When he drives himself to a gig, set gig_personnel.transport_override = 'local'.
 UPDATE users SET
     home_address   = 'Kaarina, Varsinais-Suomi',
-    transport_mode = 'car_owner'
+    transport_mode = 'passenger',
+    default_car    = 2
 WHERE username = 'valtteri.alanen';


### PR DESCRIPTION
## Summary
- Migration 013: sets `transport_mode='passenger'`, `default_car=2` for valtteri.alanen — was `car_owner` under old semantics, which made him Car 1 driver in the new person-based model and silently dropped tuomas.lundberg
- `musician_addresses.sql`: updated comment and values to match new semantics
- `TravelCalculator`: first-wins on duplicate `car_owner` for same slot; emits a named warning instead of silent overwrite

## Test plan
- [ ] Apply `make migrate-dev FILE=db/migrations/013_valtteri_transport_fix.sql`
- [ ] Recalculate travel on a gig with Tuomas + Valtteri in lineup → Tuomas is Car 1 driver, Valtteri appears in Car 2
- [ ] Recalculate travel with only Valtteri (no Tuomas) → Valtteri in Car 2 passenger slot, Car 1 route null
- [ ] Manually set two users to car_owner/default_car=1 → warning appears in route detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)